### PR TITLE
Smarter CPU affinity selection

### DIFF
--- a/kafl_fuzzer/common/util.py
+++ b/kafl_fuzzer/common/util.py
@@ -50,6 +50,7 @@ def filter_available_cpus():
     for pid in get_qemu_processes():
         cpus -= os.sched_getaffinity(pid)
     os.sched_setaffinity(0,cpus)
+    return cpus
 
 # pretty-printed hexdump
 def hexdump(src, length=16):

--- a/kafl_fuzzer/manager/core.py
+++ b/kafl_fuzzer/manager/core.py
@@ -67,7 +67,11 @@ def start(config):
     if not config.ip0:
         logger.warn("No PT trace region defined.")
 
-    filter_available_cpus()
+    cpus = filter_available_cpus()
+    if num_worker > len(cpus):
+        logger.error(f"Requested {num_worker} but only {len(cpus)} free CPUs detected. Abort.")
+        return -1
+
     manager = ManagerTask(config)
 
     workers = []

--- a/kafl_fuzzer/manager/core.py
+++ b/kafl_fuzzer/manager/core.py
@@ -19,7 +19,7 @@ import sys
 
 from kafl_fuzzer.common.logger import init_logger, logger
 from kafl_fuzzer.common.self_check import post_self_check
-from kafl_fuzzer.common.util import prepare_working_dir, copy_seed_files, qemu_sweep
+from kafl_fuzzer.common.util import prepare_working_dir, copy_seed_files, qemu_sweep, filter_available_cpus
 from kafl_fuzzer.manager.manager import ManagerTask
 from kafl_fuzzer.worker.worker import worker_loader
 
@@ -67,6 +67,7 @@ def start(config):
     if not config.ip0:
         logger.warn("No PT trace region defined.")
 
+    filter_available_cpus()
     manager = ManagerTask(config)
 
     workers = []


### PR DESCRIPTION
Individual workers now pick the Nth item out of currently configured CPU set rather than overriding an existing config. This allows to limit the cpu set more flexibly by the parent, e.g. using taskset.

Additionally, before starting the workers, the manager now performs a scan for other Qemu instances in the system and removes their respective pinned CPUs from the own available set.

Together, this should avoid the need for manually checking available CPUs and defining --cpu-offset for kafl_fuzz.py