### PR TITLE
Basic CI/CD

### DIFF
--- a/.github/actions/common-setup/action.yml
+++ b/.github/actions/common-setup/action.yml
@@ -8,6 +8,8 @@ runs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.8'
+          cache: 'pip'
+          cache-dependency-path: dev-requirements.txt
 
       - name: Install dev requirements
         run: python -m pip install -r dev-requirements.txt

--- a/.github/actions/common-setup/action.yml
+++ b/.github/actions/common-setup/action.yml
@@ -1,0 +1,14 @@
+name: 'Project setup'
+description: 'This actions will setup Python, the cache and install the dependencies'
+author: 'Mathieu Tarral'
+runs:
+    using: 'composite'
+    steps:
+      - name: Set up Python 🐍
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.8'
+
+      - name: Install dev requirements
+        run: python -m pip install -r dev-requirements.txt
+        shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - '*'
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - uses: ./.github/actions/common-setup
+
+    - name: Check format
+      run: make lint_check

--- a/Makefile
+++ b/Makefile
@@ -29,3 +29,13 @@ test:
 
 benchmark:
 	python kafl_fuzzer/test.py
+
+# Developer targets
+# requires dev-requirements.txt
+lint:
+	flake8 --show-source --statistics \
+		kafl_fuzzer *.py
+
+lint_check:
+	flake8 --count \
+		kafl_fuzzer *.py

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,4 @@
+flake8==5.0.4
+mccabe==0.7.0
+pycodestyle==2.9.1
+pyflakes==2.5.0

--- a/kafl_cov.py
+++ b/kafl_cov.py
@@ -27,10 +27,9 @@ from operator import itemgetter
 
 import msgpack
 import lz4.frame as lz4
-from tqdm import trange, tqdm
+from tqdm import tqdm
 from math import ceil
 
-import kafl_fuzzer.common.color as color
 from kafl_fuzzer.common.config import ConfigArgsParser
 from kafl_fuzzer.common.self_check import self_check, post_self_check
 from kafl_fuzzer.common.logger import init_logger, logger
@@ -38,7 +37,6 @@ from kafl_fuzzer.common.util import prepare_working_dir, read_binary_file, qemu_
 from kafl_fuzzer.worker.execution_result import ExecutionResult
 from kafl_fuzzer.worker.qemu import qemu
 
-import json
 import csv
 
 null_hash = None

--- a/kafl_cov.py
+++ b/kafl_cov.py
@@ -106,7 +106,6 @@ class TraceParser:
     def gen_reports(self):
         unique_bbs = set()
         unique_edges = dict()
-        input_to_new_bbs = list()
 
         plot_file = self.trace_dir + "/coverage.csv"
         edges_file = self.trace_dir + "/edges_uniq.lst"
@@ -324,7 +323,6 @@ def generate_traces_worker(config, pid, work_queue):
         return -1;
 
     work_dir = config.work_dir
-    trace_dir = config.input + "/traces/"
 
     signal.signal(signal.SIGTERM, sigterm_handler)
     os.setpgrp()
@@ -432,7 +430,6 @@ def simple_trace_run(q, payload, send_func):
 
 def funky_trace_run(q, input_path, retry=1):
     validations = 12
-    confirmations = 0
 
     payload = read_binary_file(input_path)
 

--- a/kafl_debug.py
+++ b/kafl_debug.py
@@ -9,9 +9,6 @@
 Execute a given kAFL target with individual test inputs for purpose of debug/inspection.
 """
 
-import os
-import sys
-
 from kafl_fuzzer.common.self_check import self_check, post_self_check
 from kafl_fuzzer.common.config import ConfigArgsParser
 from kafl_fuzzer.common.util import print_banner

--- a/kafl_fuzz.py
+++ b/kafl_fuzz.py
@@ -9,9 +9,6 @@
 Launcher for Fuzzing with kAFL. Check fuzzer/core.py for more.
 """
 
-import os
-import sys
-
 from kafl_fuzzer.common.self_check import self_check
 from kafl_fuzzer.common.config import ConfigArgsParser
 from kafl_fuzzer.common.util import print_banner

--- a/kafl_fuzzer/common/config.py
+++ b/kafl_fuzzer/common/config.py
@@ -6,12 +6,10 @@
 import argparse
 import os
 import re
-import sys
 
 import confuse
 from flatdict import FlatDict
 
-from kafl_fuzzer.common.util import is_float, is_int, Singleton
 from kafl_fuzzer.common.logger import logger
 
 

--- a/kafl_fuzzer/common/logger.py
+++ b/kafl_fuzzer/common/logger.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 #import codecs
-import os
 import sys
 import time
 

--- a/kafl_fuzzer/common/util.py
+++ b/kafl_fuzzer/common/util.py
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-import glob
 import os
 import shutil
 import sys

--- a/kafl_fuzzer/debug/core.py
+++ b/kafl_fuzzer/debug/core.py
@@ -9,10 +9,7 @@ import time
 from sys import stdout
 from threading import Thread
 
-import mmh3
-
 import kafl_fuzzer.common.color as color
-from kafl_fuzzer.common.rand import rand
 from kafl_fuzzer.common.logger import init_logger, logger
 from kafl_fuzzer.common.self_check import post_self_check
 from kafl_fuzzer.common.util import prepare_working_dir, read_binary_file, qemu_sweep

--- a/kafl_fuzzer/debug/core.py
+++ b/kafl_fuzzer/debug/core.py
@@ -8,6 +8,7 @@ import shutil
 import time
 from sys import stdout
 from threading import Thread
+from pprint import pformat
 
 import kafl_fuzzer.common.color as color
 from kafl_fuzzer.common.logger import init_logger, logger
@@ -17,7 +18,6 @@ from kafl_fuzzer.worker.execution_result import ExecutionResult
 from kafl_fuzzer.worker.qemu import qemu
 from kafl_fuzzer.technique.redqueen import parser
 from kafl_fuzzer.technique.redqueen.hash_fix import HashFixer
-from kafl_fuzzer.technique.redqueen.workdir import RedqueenWorkdir
 
 REFRESH = 0.25
 
@@ -94,7 +94,7 @@ def gdb_session(config, qemu_verbose=True, notifiers=True):
             q.set_payload(read_binary_file(payload_file))
             result = q.debug_payload()
             logger.info("Thank you for playing.")
-            #pprint(result._asdict())
+            logger.debug(pformat(result._asdict()))
     finally:
         logger.info("Shutting down..")
         q.async_exit()
@@ -379,7 +379,6 @@ def verify_dbg(config, qemu_verbose=False):
     logger.info("Starting...")
 
     rq_state = RedqueenState()
-    workdir = RedqueenWorkdir(1337)
 
     if os.path.exists("patches"):
         with open("patches", "r") as f:
@@ -439,13 +438,10 @@ def verify_dbg(config, qemu_verbose=False):
     else:
         logger.error("couldn't fix payload\n")
 
-    start = time.time()
     return 0
 
 
 def start(config):
-
-    work_dir = config.work_dir
 
     init_logger(config)
 

--- a/kafl_fuzzer/manager/bitmap.py
+++ b/kafl_fuzzer/manager/bitmap.py
@@ -7,9 +7,7 @@
 kAFL Fuzzer Bitmap
 """
 
-import array
 import ctypes
-import inspect
 import mmap
 import os
 

--- a/kafl_fuzzer/manager/manager.py
+++ b/kafl_fuzzer/manager/manager.py
@@ -113,7 +113,6 @@ class ManagerTask:
 
     def check_abort_condition(self):
         import time
-        import datetime
 
         t_limit = self.config.abort_time
         n_limit = self.config.abort_exec

--- a/kafl_fuzzer/manager/node.py
+++ b/kafl_fuzzer/manager/node.py
@@ -8,7 +8,6 @@ Fuzz inputs are managed as nodes in a queue. Any persistent metadata is stored h
 """
 
 import lz4.frame
-import mmh3
 import msgpack
 
 from kafl_fuzzer.common.util import read_binary_file, atomic_write

--- a/kafl_fuzzer/manager/queue.py
+++ b/kafl_fuzzer/manager/queue.py
@@ -8,6 +8,7 @@ Queue of fuzz inputs (nodes). Interface with scheduler to determine next input t
 """
 
 from kafl_fuzzer.manager.scheduler import Scheduler
+from kafl_fuzzer.common.logger import logger
 
 class InputQueue:
     def __init__(self, config, statistics):
@@ -93,7 +94,7 @@ class InputQueue:
         if results.get("performance"):
             oldperf = node.get_initial_performance()
             newperf = results["performance"]
-            #print("perf updated for node %d: %.2f => %.2f" % (node.get_id(), oldperf*1000,newperf*1000))
+            logger.debug("perf updated for node %d: %.2f => %.2f" % (node.get_id(), oldperf*1000,newperf*1000))
             node.set_score(self.scheduler.score_speed(node))
 
         node.set_fav_factor(self.scheduler.score_impact(node), write=False)

--- a/kafl_fuzzer/manager/queue.py
+++ b/kafl_fuzzer/manager/queue.py
@@ -8,7 +8,6 @@ Queue of fuzz inputs (nodes). Interface with scheduler to determine next input t
 """
 
 from kafl_fuzzer.manager.scheduler import Scheduler
-from kafl_fuzzer.common.logger import logger
 
 class InputQueue:
     def __init__(self, config, statistics):

--- a/kafl_fuzzer/manager/scheduler.py
+++ b/kafl_fuzzer/manager/scheduler.py
@@ -25,8 +25,6 @@ execution/finding rate.
 
 from math import log, log2, log10, ceil
 
-from kafl_fuzzer.common import logger
-
 # scale arbitrarily large / small inputs down to interval [1,scale]
 # supply alternative log to get a better fit
 def log_scale(value, base=2):

--- a/kafl_fuzzer/technique/arithmetic.py
+++ b/kafl_fuzzer/technique/arithmetic.py
@@ -7,8 +7,6 @@
 Reimplementation of AFL-style arithmentic mutations (deterministic stage).
 """
 
-from binascii import hexlify
-
 from kafl_fuzzer.technique.helper import *
 
 

--- a/kafl_fuzzer/technique/grimoire_inference.py
+++ b/kafl_fuzzer/technique/grimoire_inference.py
@@ -12,9 +12,6 @@ import re
 from collections import OrderedDict
 from six.moves import map
 
-from kafl_fuzzer.common import logger
-
-
 class GrimoireInference:
 
     def __init__(self, config, verify_input):

--- a/kafl_fuzzer/technique/grimoire_mutations.py
+++ b/kafl_fuzzer/technique/grimoire_mutations.py
@@ -7,7 +7,6 @@
 Grimoire grammar-based mutations (havoc stage)
 """
 
-from kafl_fuzzer.common.logger import logger
 from kafl_fuzzer.common.rand import rand
 
 CHOOSE_SUBINPUT = 50

--- a/kafl_fuzzer/technique/havoc_handler.py
+++ b/kafl_fuzzer/technique/havoc_handler.py
@@ -252,7 +252,6 @@ redqueen_seen_addr_to_value = {}
 def set_dict(new_dict):
     global dict_import
     dict_import = new_dict
-    dict_set = set(new_dict)
 
 
 def clear_redqueen_dict():

--- a/kafl_fuzzer/technique/havoc_handler.py
+++ b/kafl_fuzzer/technique/havoc_handler.py
@@ -7,7 +7,6 @@
 AFL-style havoc mutations (havoc stage)
 """
 
-from kafl_fuzzer.common.logger import logger
 from kafl_fuzzer.common.rand import rand
 from kafl_fuzzer.common.util import read_binary_file, find_diffs
 from kafl_fuzzer.technique.helper import *

--- a/kafl_fuzzer/technique/helper.py
+++ b/kafl_fuzzer/technique/helper.py
@@ -7,13 +7,10 @@
 Helper functions used by fuzzing inference and mutation algorithms
 """
 
-import glob
-import inspect
-import os
 import struct
 
 import ctypes
-from ctypes import c_uint8, c_uint16, c_uint32
+from ctypes import c_uint8, c_uint32
 
 from kafl_fuzzer.common.rand import rand
 from kafl_fuzzer.native import loader as native_loader

--- a/kafl_fuzzer/technique/interesting_values.py
+++ b/kafl_fuzzer/technique/interesting_values.py
@@ -7,8 +7,6 @@
 AFL-style 'interesting values' mutations (deterministic stage).
 """
 
-from binascii import hexlify
-
 from kafl_fuzzer.technique.helper import *
 
 

--- a/kafl_fuzzer/technique/radamsa.py
+++ b/kafl_fuzzer/technique/radamsa.py
@@ -61,7 +61,7 @@ def perform_radamsa_round(data, func, num_inputs):
                     os.remove(input_dir+path)
                 p.communicate(timeout=1)
                 break
-            except subprocess.SubprocessError as e:
+            except subprocess.SubprocessError:
                 pass
     except SystemExit:
         # be sure to cleanup on kill signal

--- a/kafl_fuzzer/technique/redqueen/cmp.py
+++ b/kafl_fuzzer/technique/redqueen/cmp.py
@@ -8,7 +8,6 @@ Redqueen Input Analysis
 """
 
 import itertools
-import re
 import struct
 
 from kafl_fuzzer.common.logger import logger

--- a/kafl_fuzzer/technique/redqueen/cmp.py
+++ b/kafl_fuzzer/technique/redqueen/cmp.py
@@ -51,7 +51,6 @@ class Cmp:
         self.hammer = (not self.addr in known_lea_offsets) and (self.type in ["LEA", "SUB", "ADD"])
         known_lea_offsets.add(self.addr)
         self.offsets_and_lhs_to_rhs = {}
-        index = None
 
     def add_result(self, run_info, lhs, rhs):
         self.run_info_to_pairs[run_info] = self.run_info_to_pairs.get(run_info, set())

--- a/kafl_fuzzer/technique/redqueen/colorize.py
+++ b/kafl_fuzzer/technique/redqueen/colorize.py
@@ -9,7 +9,6 @@ Redqueen Input Colorizer
 
 import array
 
-from kafl_fuzzer.common import rand
 
 
 # definition of range indicies:

--- a/kafl_fuzzer/technique/redqueen/colorize.py
+++ b/kafl_fuzzer/technique/redqueen/colorize.py
@@ -74,7 +74,6 @@ def check_nondet(min_, max_, array):
 class TestColorizer(unittest.TestCase):
 
     def check_fuzz_result(self, i, testcase):
-        color_info = [0] * len(testcase)
         c = ColorizerStrategy(len(testcase), lambda min_, max_: check(min_, max_, testcase))
         while len(c.unknown_ranges) > 0:
             # print c.unknown_ranges
@@ -84,10 +83,9 @@ class TestColorizer(unittest.TestCase):
         assert (all([x != 0 for x in c.color_info]))
 
     def check_nondet_fuzz_result(self, i, testcase):
-        color_info = [0] * len(testcase)
         c = ColorizerStrategy(len(testcase), lambda min_, max_: check_nondet(min_, max_, testcase))
         while len(c.unknown_ranges) > 0:
-            offset = c.colorize_step()
+            c.colorize_step()
         print("nondet:", c.color_info)
         if not all([x != 0 for x in c.color_info]):
             assert (False)

--- a/kafl_fuzzer/technique/redqueen/hash_fix.py
+++ b/kafl_fuzzer/technique/redqueen/hash_fix.py
@@ -136,7 +136,6 @@ class HashFixer:
     def try_fix_cmp(self, shape, fixed_data, run_info, cmp):
         known_offsets = self.redqueen_state.get_candidate_file_offsets(cmp.addr)
         logger.debug("known offsets for: %x = %s" % (cmp.addr, known_offsets))
-        mutations = [x for x in cmp.calc_mutations(run_info, 1)]
         for (offsets, lhs, rhs, enc) in cmp.calc_mutations(run_info, 1):
             if offsets in known_offsets:
                 if self.try_fix_cmp_with(shape, fixed_data, cmp, offsets, lhs, rhs, enc):

--- a/kafl_fuzzer/technique/redqueen/mod.py
+++ b/kafl_fuzzer/technique/redqueen/mod.py
@@ -9,10 +9,8 @@ Redqueen execution inference & deterministic insertion (inference stage)
 
 import os.path
 
-from array import array
 from shutil import copyfile, rmtree
 
-from kafl_fuzzer.common import logger
 from .parser import parse_rq
 
 MAX_NUMBER_PERMUTATIONS = 1000  # number of trials per address, lhs and encoding

--- a/kafl_fuzzer/tests/redqueen_mut.py
+++ b/kafl_fuzzer/tests/redqueen_mut.py
@@ -12,7 +12,6 @@ Validate Redqueen Input-to-State mutations
 import array
 import sys
 
-from fuzzer.technique.redqueen import parser
 from fuzzer.technique.redqueen.mod import RedqueenInfoGatherer
 
 info = RedqueenInfoGatherer()

--- a/kafl_fuzzer/tests/test_deterministic.py
+++ b/kafl_fuzzer/tests/test_deterministic.py
@@ -5,8 +5,6 @@
 Test kAFL deterministic mutations
 """
 
-import os
-import struct
 import random
 from binascii import hexlify
 
@@ -14,7 +12,7 @@ from kafl_fuzzer.technique.interesting_values import *
 from kafl_fuzzer.technique.arithmetic import *
 from kafl_fuzzer.technique.bitflip import *
 from kafl_fuzzer.technique.helper import *
-from kafl_fuzzer.tests.helper import ham_distance, ham_weight, bindiff
+from kafl_fuzzer.tests.helper import ham_distance
 
 def generate_effector_map(length):
     eff_map = []

--- a/kafl_fuzzer/tests/test_deterministic.py
+++ b/kafl_fuzzer/tests/test_deterministic.py
@@ -108,7 +108,6 @@ def assert_bitflip_invariants(func, flipped_bits, loops, skips, payloads):
 def test_invariants(v=False):
 
     old=False
-    verbose=False
 
     payloads = []
     for length in [range(0, 3), 16, 23, 33]:
@@ -156,7 +155,6 @@ def test_invariants(v=False):
 def assert_func_num_calls(func, payload, expected_calls, v=False):
 
     global calls
-    skip_zero = False
     calls = 0
 
     def verifier(outdata, label=None):
@@ -350,8 +348,6 @@ def test_int_32_call_num():
 import timeit
 def deter_benchmark():
 
-    verbose=False
-    old=False
     payloads = [b'abcdefghijklmnopqrstuvwxyz01234567890', bytes([254,255,255,254,255,254,252])]
 
     def bench_arith_8():
@@ -413,9 +409,7 @@ def deter_main():
     deter_benchmark()
     return
 
-    verbose=True
-
-    payloads = [b'\x00', b'abcdefghijk', bytes([0,1,2,3,4,5,6,7,8,9]), bytes([254,255,255,254,255,254,252])]
+    # payloads = [b'\x00', b'abcdefghijk', bytes([0,1,2,3,4,5,6,7,8,9]), bytes([254,255,255,254,255,254,252])]
     #payloads = [b'abcdefghijk']
     #payloads = [b'\x00\x00']
 

--- a/kafl_fuzzer/tests/test_havoc_handler.py
+++ b/kafl_fuzzer/tests/test_havoc_handler.py
@@ -5,13 +5,12 @@
 Test kAFL havoc mutations
 """
 
-import unittest, os
 import struct
 from binascii import hexlify
 
 from kafl_fuzzer.technique.havoc_handler import *
 from kafl_fuzzer.technique.helper import *
-from kafl_fuzzer.tests.helper import ham_distance, ham_weight
+from kafl_fuzzer.tests.helper import ham_distance
 
 EMPTY_DICT = {}
 EMPTY_ARRAY = []

--- a/kafl_fuzzer/tests/test_random.py
+++ b/kafl_fuzzer/tests/test_random.py
@@ -132,7 +132,6 @@ def test_coin_semantics():
     for _ in range(samples):
         if rand.int(2) == 0: # chance 1 out of 2
             check += 1
-    real = check/samples
 
     assert(abs(check/samples - 1/2) < 0.1), "Coin toss bias - semantics mismatch?"
 

--- a/kafl_fuzzer/tests/test_random.py
+++ b/kafl_fuzzer/tests/test_random.py
@@ -6,7 +6,6 @@ Test kAFL rand() wrapper / coin toss
 """
 
 import random
-import fastrand
 
 from kafl_fuzzer.technique.helper import rand
 

--- a/kafl_fuzzer/worker/qemu.py
+++ b/kafl_fuzzer/worker/qemu.py
@@ -49,7 +49,6 @@ class qemu:
         self.persistent_runs = 0
 
         work_dir = self.config.work_dir
-        project_name = work_dir.split("/")[-1]
 
         self.qemu_aux_buffer_filename = work_dir + "/aux_buffer_%d" % self.pid
 

--- a/kafl_fuzzer/worker/qemu.py
+++ b/kafl_fuzzer/worker/qemu.py
@@ -18,7 +18,6 @@ import time
 import shutil
 
 from kafl_fuzzer.common.logger import logger
-from kafl_fuzzer.common.util import read_binary_file, atomic_write, strdump, print_hprintf
 from kafl_fuzzer.technique.redqueen.workdir import RedqueenWorkdir
 from kafl_fuzzer.worker.execution_result import ExecutionResult
 from kafl_fuzzer.worker.qemu_aux_buffer import QemuAuxBuffer

--- a/kafl_fuzzer/worker/qemu_aux_buffer.py
+++ b/kafl_fuzzer/worker/qemu_aux_buffer.py
@@ -11,7 +11,6 @@ from collections import namedtuple
 from enum import IntEnum
 
 from kafl_fuzzer.common import logger
-from kafl_fuzzer.common.util import strdump
 
 
 result_tuple = namedtuple('result_tuple', [

--- a/kafl_fuzzer/worker/state_logic.py
+++ b/kafl_fuzzer/worker/state_logic.py
@@ -265,11 +265,6 @@ class FuzzingStateLogic:
         self.redqueen_time += time.time() - redqueen_start_time
 
     def handle_havoc(self, payload, metadata):
-        grimoire_time = 0
-        havoc_time = 0
-        splice_time = 0
-        radamsa_time = 0
-
         havoc_afl = True
         havoc_splice = True
         havoc_radamsa = self.config.radamsa
@@ -277,8 +272,6 @@ class FuzzingStateLogic:
         havoc_redqueen = self.config.redqueen
 
         for i in range(1):
-            initial_findings = self.stage_info_findings
-
             # Dict based on RQ learned tokens
             # TODO: AFL only has deterministic dict stage for manual dictionary.
             # However RQ dict and auto-dict actually grow over time. Perhaps

--- a/kafl_fuzzer/worker/state_logic.py
+++ b/kafl_fuzzer/worker/state_logic.py
@@ -8,7 +8,6 @@ Main logic used by Worker to push nodes through various fuzzing stages/mutators.
 """
 
 import time
-from array import array
 
 from kafl_fuzzer.common.logger import logger
 from kafl_fuzzer.common.rand import rand

--- a/kafl_fuzzer/worker/worker.py
+++ b/kafl_fuzzer/worker/worker.py
@@ -22,7 +22,6 @@ import lz4.frame as lz4
 #from kafl_fuzzer.common.config import FuzzerConfiguration
 from kafl_fuzzer.common.logger import logger
 from kafl_fuzzer.common.rand import rand
-from kafl_fuzzer.common.util import read_binary_file, atomic_write
 from kafl_fuzzer.manager.bitmap import BitmapStorage, GlobalBitmap
 from kafl_fuzzer.manager.communicator import ClientConnection, MSG_IMPORT, MSG_RUN_NODE, MSG_BUSY
 from kafl_fuzzer.manager.node import QueueNode

--- a/kafl_gui.py
+++ b/kafl_gui.py
@@ -182,7 +182,6 @@ def ptime(secs):
 
 def atime(secs):
     secs = int(secs)
-    seconds = secs % 60
     secs //= 60
     mins = secs % 60
     secs //= 60
@@ -818,7 +817,7 @@ if __name__ == "__main__":
 
     try:
         curses.wrapper(main)
-    except FileNotFoundError as e:
+    except FileNotFoundError:
         # ignore - typically just a fuzzer restart or wrong argv[1]
         print("Error reading from workdir. Exit.")
     except KeyboardInterrupt:

--- a/kafl_plot.py
+++ b/kafl_plot.py
@@ -90,7 +90,6 @@ class Graph:
         plen = node.get("payload_len",1)
         perf = node.get("performance", node["info"]['performance'])
         favs = node.get("fav_bits", "")
-        level = node.get("level")
         exit = node["info"]["exit_reason"]
         parent = node["info"]["parent"]
         method = node["info"]["method"]

--- a/kafl_plot.py
+++ b/kafl_plot.py
@@ -11,15 +11,10 @@ Optionally also visualize this output using an xdot graph.
 
 """
 
-import os
 import sys
 import time
 import glob
-import string
-import binascii
 import msgpack
-from datetime import timedelta
-from pprint import pprint
 
 import pygraphviz as pgv
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 120
+select = F401,F841


### PR DESCRIPTION
New makefile targets
- `lint`: runs flake8
- `lint_check`: runs flake8 and count the number of errors

Tools used:
- flake8

Configuration
- max-line-length: 120
- select: F401 and F841 (unused imports and variable assignments)

There are so many lint warnings and error that it's a better strategy to select and enable lint categories one by one in multiple PRs.