### PR TITLE
tests: initialize mutation helper non-class for pytest

### DIFF
--- a/kafl_fuzzer/tests/test_deterministic.py
+++ b/kafl_fuzzer/tests/test_deterministic.py
@@ -16,6 +16,8 @@ from kafl_fuzzer.technique.bitflip import *
 from kafl_fuzzer.technique.helper import *
 from kafl_fuzzer.tests.helper import ham_distance, ham_weight, bindiff
 
+helper_init()
+
 def generate_effector_map(length):
     eff_map = []
     for i in range(length):

--- a/kafl_fuzzer/tests/test_havoc_handler.py
+++ b/kafl_fuzzer/tests/test_havoc_handler.py
@@ -18,6 +18,8 @@ EMPTY_ARRAY = []
 
 ITERATIONS=2*1024
 
+helper_init()
+
 def test_redqueen_dict_clear():
     clear_redqueen_dict()
     assert(EMPTY_DICT == get_redqueen_dict()), "Failed to clear RQ dict!"
@@ -127,8 +129,6 @@ def test_havoc_insert_line(v=False):
 
 
 def havoc_main():
-
-    return
 
     test_redqueen_dict_clear()
     test_redqueen_dict_add()


### PR DESCRIPTION
- changed bitmap loading broke the tests
- adding helper_init() to global scope makes it work

$ make env
$ cd $KAFL_ROOT/fuzzer
$ pip install pytest
$ make test
$ make benchmark