### PR TITLE
cpu affinity: try to continue even if cpus seem busy

### DIFF
--- a/kafl_fuzzer/common/util.py
+++ b/kafl_fuzzer/common/util.py
@@ -40,18 +40,18 @@ def qemu_sweep(msg):
     if (len(pids) > 0):
         logger.warn(msg + " " + repr(pids))
 
-# limit ourselves to CPUs not hogged by possible other qemu instances
+# filter available CPUs by those with existing qemu instances
 def filter_available_cpus():
     def get_qemu_processes():
         for proc in psutil.process_iter(['pid', 'name']):
             if 'qemu-system-x86_64' in proc.info['name']:
                 yield (proc.info['pid'])
 
-    cpus = os.sched_getaffinity(0)
+    avail = os.sched_getaffinity(0)
+    used = set()
     for pid in get_qemu_processes():
-        cpus -= os.sched_getaffinity(pid)
-    os.sched_setaffinity(0,cpus)
-    return cpus
+        used |= os.sched_getaffinity(pid)
+    return avail, used
 
 # pretty-printed hexdump
 def hexdump(src, length=16):


### PR DESCRIPTION
- when the set of free cpus is empty, previous code died already when attempting to set the affinity in filter_available_cpus()
- warn but do not abort if auto-detection indicates that available cpus are already occupied. it could be zombies or debug instances..