### PR TITLE
improve startup/failure reporting of Worker instances

### DIFF
--- a/kafl_fuzzer/manager/communicator.py
+++ b/kafl_fuzzer/manager/communicator.py
@@ -90,4 +90,4 @@ class ClientConnection:
 
     def send_node_abort(self, node_id, results):
         self.sock.send_bytes(msgpack.packb(
-            {"type": MSG_NODE_ABORT, "node_id": node_id, "results": results}))
+            {"type": MSG_NODE_ABORT, "node_id": node_id, "results": results, "worker_id": self.pid}))

--- a/kafl_fuzzer/worker/qemu.py
+++ b/kafl_fuzzer/worker/qemu.py
@@ -368,7 +368,7 @@ class qemu:
         msg = msg.decode('latin-1', errors='backslashreplace')
         msg = "Guest ABORT: %s" % msg
 
-        self.logger.error("Guest ABORT: %s", msg)
+        self.logger.error(msg)
         if self.hprintf_log:
             with open(self.hprintf_logfile, "a") as f:
                 f.write(msg)


### PR DESCRIPTION
This prevents printing fuzzer status line when actually still waiting for Workers/Qemu to boot.
It also detects when Qemu instances abort/exit, in particular the first Worker may abort and others never become READY due to missing created snapshot image. Previously, the manager would just keep waiting for other Workers to come online.

In detail:
- on ABORT hypercall and/or QemuIOException, let workers send ABORT msg to manager thread
- also send ABORT on Qemu startup to catch exit due to malformed qemu cmdline etc.
- update manager to keep track of READY vs ABORTed workers
  - do not print status line before first worker has become ready
    (this leaves the previous printed status messages, "waiting for snapshot" or "waiting for VM to start")
  - once at least one Worker has become ready (successful boot + snapshot created), check that set of READY workers is bigger than ABORTed workers, and exit otherwise

To test:
- launch the fuzzer with bad qemu options, e.g. "qemu_extra: -foobar"
- launch a harness that errors out, e.g. trigger ABORT hypercall before / after snapshot