### PR TITLE
cpu affinity: consider --cpu-offset as override to auto-detection

### DIFF
--- a/kafl_fuzzer/manager/core.py
+++ b/kafl_fuzzer/manager/core.py
@@ -81,11 +81,12 @@ def start(config):
         logger.error(f"Requested {num_worker} workers but only {len(avail)} vCPUs detected.")
         return 1
 
-    # warn if we cannot limit ourselves to CPUs detected as free..
+    # warn if assigned cpu set seems to be used by other Qemu instances already
+    # attempt to confine ourselves to unused set, unless --cpu-offset override was given
     if num_worker + 1 >= len(avail-used):
         logger.warn(f"Warning: Requested {num_worker} workers but {len(used)} out of {len(avail)} vCPUs seem busy?")
         time.sleep(2)
-    else:
+    elif not config.cpu_offset:
         os.sched_setaffinity(0, avail-used)
 
     manager = ManagerTask(config)


### PR DESCRIPTION
The --cpu-offset arugment was incompatible with automated detection of free/busy CPUs. The reduced cpu set is not obvious during startup time and we may fail to launch workers if cpu set + cpu offset < workers.

This patch disables auto-detection of free vcpus if a --cpu-offset is given. This restores the original semantics of --cpu-offset.