### PR TITLE
qemu.py: redirect qemu outputs on --log

### DIFF
--- a/kafl_fuzzer/worker/qemu.py
+++ b/kafl_fuzzer/worker/qemu.py
@@ -110,10 +110,10 @@ class qemu:
 
         self.cmd.extend(["-m", str(config.qemu_memory)])
 
-        if self.debug_mode and self.config.log:
-            #self.cmd.extend("-trace", "events=/tmp/events"])
-            #self.cmd.extend("-d", "kafl", "-D", "self.qemu_trace_log"])
-            pass
+        if self.config.log:
+            self.cmd.extend(["-d", "nyx", "-D", self.qemu_trace_log])
+            #self.cmd.extend(["-d", "kafl,trace:kvm*"])
+            #self.cmd.extend(["-trace", "events=/tmp/events"])
 
         if self.config.gdbserver:
             self.cmd.extend(["-s", "-S"])


### PR DESCRIPTION
This allows to redirect qemu log output based on recent QemuNyx changes.

When building QemuNyx in debug mode, additional output can be produced via the 'nyx' log facility.
Enable this by default when --log is given.