### PR TITLE
also detect qemu.start() failure and avoid double-shutdown

### DIFF
--- a/kafl_fuzzer/manager/manager.py
+++ b/kafl_fuzzer/manager/manager.py
@@ -117,10 +117,13 @@ class ManagerTask:
                     raise ValueError("unknown message type {}".format(msg))
 
             # start printing status when first instance is ready - or exit when they died
-            if len(workers_ready) > 0:
+            if workers_ready:
                 if (len(workers_ready - workers_aborted)) == 0:
                     raise SystemExit("All Workers have died, or aborted before they became ready. :-/")
                 self.statistics.maybe_write_stats()
+            elif workers_aborted:
+                raise SystemExit("Workers aborted before becoming ready. Likely broken VM or agent setup.")
+
             self.check_abort_condition()
 
 

--- a/kafl_fuzzer/worker/qemu.py
+++ b/kafl_fuzzer/worker/qemu.py
@@ -182,7 +182,7 @@ class qemu:
             except:
                 pass
 
-        self.logger.info("exit code: %s", str(self.process.returncode))
+        self.logger.debug(f"Qemu exit code: {self.process.returncode}")
 
         if len(output) > 0:
             header = "\n=================<%s Console Output>==================\n" %self
@@ -269,10 +269,10 @@ class qemu:
         try:
             self.__qemu_connect()
             self.__qemu_handshake()
-        except (OSError, BrokenPipeError) as e:
+        except (OSError, BrokenPipeError, QemuIOException) as e:
             if not self.exiting:
                 self.logger.error("Failed to connect to Qemu: %s", str(e))
-                self.shutdown()
+                self.async_exit()
             return False
 
         self.logger.debug("Handshake done.")

--- a/kafl_fuzzer/worker/worker.py
+++ b/kafl_fuzzer/worker/worker.py
@@ -130,6 +130,7 @@ class WorkerTask:
                 self.loop()
             else:
                 self.logger.error("Failed to launch Qemu.")
+                self.conn.send_node_abort(None, None)
         except QemuIOException:
             # Qemu has likely died on us - try to restart?
             pass


### PR DESCRIPTION
This improves on #25 which was not handling errors during qemu.start() phase. In this case, the Worker-00 will typically not create the snapshot, which leads all other Workers to wait forever on snapshot creation.

Fix:
- on Qemu ABORT event or any other qemu.start() failure, let Worker send ABORT to manager
- in manager, if no Workers are ready but someone has aborted, exit and kill them all.
- also, use qemu.async_exit() to avoid duplicate execution of qemu.shutdown()