### PR TITLE
CI: add release job triggered by v* tags

### DIFF
--- a/.github/RELEASE.md
+++ b/.github/RELEASE.md
@@ -1,0 +1,7 @@
+# 🌟 Features
+
+# 🔧 Fixes
+
+# 📖 Documentation
+
+# 🧰 Behind the scenes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,3 +19,30 @@ jobs:
 
     - name: Check format
       run: make lint_check
+
+  release:
+    # this job makes an official Github release
+    needs: [lint]
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.get_version.outputs.version }}
+      upload_url: ${{ steps.step_upload_url.outputs.upload_url }}
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Get the version
+        id: get_version
+        run: echo ::set-output name=version::${GITHUB_REF/refs\/tags\//}
+
+      # only create release if tag start by 'v*'
+      - name: Create a Release
+        id: create_release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ steps.get_version.outputs.version }}
+          body_path: ${{ github.workspace }}/.github/RELEASE.md
+        if: startsWith(github.ref, 'refs/tags/v')
+
+      - id: step_upload_url
+        run: echo "::set-output name=upload_url::${{ steps.create_release.outputs.upload_url }}"


### PR DESCRIPTION
- add `.github/RELEASE.md`  to be filled with release details.
- add `release` job depending on `lint` job and tag having `v*` pattern