### PR TITLE
setup: fix including default_settings.yaml in the final distribution

### DIFF
--- a/.github/RELEASE.md
+++ b/.github/RELEASE.md
@@ -18,6 +18,7 @@
 # 🔧 Fixes
 
 - avoid Qemu hang when handling ABORT in pre-init phase (#34)
+- fix including `default_settings.yaml` in the final package (#35)
 
 # 📖 Documentation
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(name='kafl_fuzzer',
       url='https://github.com/IntelLabs/kAFL',
       install_requires=requirements,
       packages=find_packages(),
-      package_data={'kafl_fuzzer': ['logging.yaml']},
+      package_data={'kafl_fuzzer': ['logging.yaml', 'common/config/default_settings.yaml']},
       include_package_data=True,
       ext_modules = [
           Extension('kafl_fuzzer.native.bitmap',


### PR DESCRIPTION
`default_settings.yaml` was not included in the installed kafl_fuzzer package