### PR TITLE
fuzzer: use bitmap.so compiled as Extension by setup.py

### DIFF
--- a/kafl_fuzzer/common/self_check.py
+++ b/kafl_fuzzer/common/self_check.py
@@ -10,12 +10,7 @@ import multiprocessing
 import logging
 from fcntl import ioctl
 
-from kafl_fuzzer.native import loader as native_loader
-
 logger = logging.getLogger(__name__)
-
-def check_if_nativ_lib_compiled():
-    return native_loader.test_build()
 
 def check_version():
     if sys.version_info < (3, 6, 0):
@@ -163,8 +158,6 @@ def check_cpu_num(config):
     return True
 
 def self_check():
-    if not check_if_nativ_lib_compiled():
-        return False
     if not check_version():
         return False
     if not check_packages():

--- a/kafl_fuzzer/manager/bitmap.py
+++ b/kafl_fuzzer/manager/bitmap.py
@@ -7,17 +7,21 @@
 kAFL Fuzzer Bitmap
 """
 
+import logging
 import ctypes
 import mmap
 import os
 
 from kafl_fuzzer.native import loader as native_loader
 
+logger = logging.getLogger(__name__)
+
 class GlobalBitmap:
     bitmap_native_so = None
 
     def __init__(self, name, config, read_only=True):
         if not GlobalBitmap.bitmap_native_so:
+            logger.debug("Loading bitmap.so from %s", native_loader.bitmap_path())
             GlobalBitmap.bitmap_native_so = ctypes.CDLL(native_loader.bitmap_path())
             GlobalBitmap.bitmap_native_so.are_new_bits_present_no_apply_lut.restype = ctypes.c_uint64
             GlobalBitmap.bitmap_native_so.are_new_bits_present_do_apply_lut.restype = ctypes.c_uint64

--- a/kafl_fuzzer/native/Makefile
+++ b/kafl_fuzzer/native/Makefile
@@ -1,2 +1,0 @@
-bitmap.so: bitmap.c
-	$(CC) --shared -fPIC -O3 -o $@ $^

--- a/kafl_fuzzer/native/loader.py
+++ b/kafl_fuzzer/native/loader.py
@@ -11,39 +11,14 @@ Helper for loading C extension
 import glob
 import inspect
 import os
-import subprocess
 import logging
 
 import kafl_fuzzer.native as native_pkg
 
 logger = logging.getLogger(__name__)
 
-def test_build():
-    native_path = os.path.dirname(inspect.getfile(native_pkg))
-    bitmap_paths = glob.glob(native_path + "/bitmap*so")
-
-    if len(bitmap_paths) < 1:
-        logger.warn("Attempting to build native/bitmap.so ...")
-
-        p = subprocess.Popen(("make -C " + native_path).split(" "),
-                             stdout=subprocess.PIPE, stdin=subprocess.PIPE, stderr=subprocess.PIPE)
-
-        if p.wait() != 0:
-            logger.error("Build failed, please check..")
-            return False
-
-    bitmap_paths = glob.glob(native_path + "/bitmap*so")
-    assert len(bitmap_paths) > 0, "Failed to resolve native bitmap.so library."
-    return True
-
 def bitmap_path():
     native_path = os.path.dirname(inspect.getfile(native_pkg))
     bitmap_paths = glob.glob(native_path + "/bitmap*so")
     assert len(bitmap_paths) > 0, "Failed to resolve native bitmap.so library."
     return bitmap_paths[0]
-
-#bitmap_native_so = None
-#
-#if not bitmap_native_so:
-#    bitmap_native_so = load_native()
-


### PR DESCRIPTION
Load `bitmap.so` only using the compiled version by `setup.py` 's `Extension` module.
Don't use the custom `Makefile` at runtime to compile it, and remove that code anyway.
Also remove check if the library is compiled, since it will be compiled by `setup.py`