### PR TITLE
fuzzer: refactor logging to dump state of loaded config before validation

### DIFF
--- a/.github/RELEASE.md
+++ b/.github/RELEASE.md
@@ -13,7 +13,8 @@
     - option `--afl-skip-ranges` has been removed (never used anyway)
     - removed config override via `$PWD/kafl.yaml` (not explicit, users don't expect that behavior)
     - rename and reformat `$WORKDIR/config` (MessagePack) -> `$WORKDIR/config.yaml` (YAML)
-
+- add early logging of fuzzer loaded configuration before validation (#38)
+    - deprecate `KAFL_CONFIG_DEBUG`
 
 # 🔧 Fixes
 

--- a/kafl_fuzzer/__main__.py
+++ b/kafl_fuzzer/__main__.py
@@ -3,7 +3,11 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
+import logging
+from pprint import pformat
+
 from kafl_fuzzer.common.config import settings, update_from_namespace, validate, ConfigParserBuilder
+from kafl_fuzzer.common.logger import setup_basic_logging
 
 def main():
     parser_builder = ConfigParserBuilder()
@@ -12,7 +16,19 @@ def main():
     args = parser.parse_args()
     # override Dynaconf settings with command line settings
     update_from_namespace(args)
+    # before validation, setup logging on stdout
+    # and dump currently loaded config
+    setup_basic_logging(settings)
+    logger = logging.getLogger(__name__)
+    logger.debug("Loaded configuration files:")
+    logger.debug(pformat(settings._loaded_files))
+    logger.debug("Command line configuration:")
+    logger.debug(pformat(vars(args)))
+    logger.debug("Loaded configuration values:")
+    logger.debug(pformat(settings._loaded_by_loaders))
     # validate settings
     validate()
+    logger.debug("Final configuration:")
+    logger.debug(pformat(settings.to_dict()))
     # call subcommand assigned default start func
     args.func(settings)

--- a/kafl_fuzzer/common/config/cmdline.py
+++ b/kafl_fuzzer/common/config/cmdline.py
@@ -16,12 +16,12 @@
 # through settings.py:validate()
 
 import argparse
-import os
 import logging
 from enum import Enum, auto
 from argparse import _SubParsersAction, ArgumentParser
 from typing import Any
 
+from .settings import settings
 from kafl_fuzzer.manager.core import start as fuzz_start
 from kafl_fuzzer.debug.core import start as debug_start
 from kafl_fuzzer.coverage import start as cov_start
@@ -52,7 +52,7 @@ logger = logging.getLogger(__name__)
 
 
 def hidden(msg, unmask=False):
-    if unmask or 'KAFL_CONFIG_DEBUG' in os.environ:
+    if unmask or settings.debug:
         return msg
     return argparse.SUPPRESS
 

--- a/kafl_fuzzer/coverage/__init__.py
+++ b/kafl_fuzzer/coverage/__init__.py
@@ -33,7 +33,7 @@ from tqdm import tqdm
 from math import ceil
 
 from kafl_fuzzer.common.self_check import self_check, post_self_check
-from kafl_fuzzer.common.logger import setup_logging
+from kafl_fuzzer.common.logger import add_logging_file
 from kafl_fuzzer.common.util import prepare_working_dir, read_binary_file, qemu_sweep, print_banner
 from kafl_fuzzer.worker.execution_result import ExecutionResult
 from kafl_fuzzer.worker.qemu import qemu
@@ -324,7 +324,7 @@ def generate_traces_worker(config, pid, work_queue):
         logger.error("Failed to prepare working directory. Exit.")
         return -1;
 
-    setup_logging(config)
+    add_logging_file(config)
 
     work_dir = config.work_dir
 

--- a/kafl_fuzzer/debug/core.py
+++ b/kafl_fuzzer/debug/core.py
@@ -15,7 +15,7 @@ from dynaconf import LazySettings
 
 import kafl_fuzzer.common.color as color
 from kafl_fuzzer.common.util import print_banner
-from kafl_fuzzer.common.logger import setup_logging
+from kafl_fuzzer.common.logger import add_logging_file
 from kafl_fuzzer.common.self_check import self_check, post_self_check
 from kafl_fuzzer.common.util import prepare_working_dir, read_binary_file, qemu_sweep
 from kafl_fuzzer.worker.execution_result import ExecutionResult
@@ -444,7 +444,7 @@ def start(settings: LazySettings):
 
     # initialize logger after work_dir purge
     # otherwise the file handler created is removed
-    setup_logging(settings)
+    add_logging_file(settings)
     # log config parameters
     logging.debug(pformat(settings))
 

--- a/kafl_fuzzer/manager/core.py
+++ b/kafl_fuzzer/manager/core.py
@@ -25,7 +25,7 @@ from dynaconf import LazySettings
 from kafl_fuzzer.common.util import print_banner
 from kafl_fuzzer.common.self_check import self_check, post_self_check
 from kafl_fuzzer.common.util import prepare_working_dir, copy_seed_files, qemu_sweep, filter_available_cpus
-from kafl_fuzzer.common.logger import setup_logging
+from kafl_fuzzer.common.logger import add_logging_file
 from kafl_fuzzer.manager.manager import ManagerTask
 from kafl_fuzzer.worker.worker import worker_loader
 
@@ -68,7 +68,7 @@ def start(settings: LazySettings):
 
     # initialize logger after work_dir purge
     # otherwise the file handler created is removed
-    setup_logging(settings)
+    add_logging_file(settings)
     # log config parameters
     logging.debug(pformat(settings))
 

--- a/kafl_fuzzer/manager/core.py
+++ b/kafl_fuzzer/manager/core.py
@@ -18,7 +18,6 @@ import time
 import os
 import sys
 import logging
-from pprint import pformat
 
 from dynaconf import LazySettings
 
@@ -69,8 +68,6 @@ def start(settings: LazySettings):
     # initialize logger after work_dir purge
     # otherwise the file handler created is removed
     add_logging_file(settings)
-    # log config parameters
-    logging.debug(pformat(settings))
 
     if seed_dir:
         if not copy_seed_files(work_dir, seed_dir):


### PR DESCRIPTION
I refactored the `logger.py` to split the main `setup_logging()` function into 2 functions
- `load_logging_config()`: simply loads the `logging.yaml` config file, and store it in a global variable
- `setup_basic_logging()`: setup console, useful to log loaded configuration before validation happens
- `add_file_logging()`: add `$WORKDIR/kafl_fuzzer.log` if `--log` has been specified

Finally I dump all possible info I could find about the loaded kAFL configuration, in order to simplify detecting config issues.
First: `Loaded configuration files`
![image](https://user-images.githubusercontent.com/964610/204858581-f6ddd9a9-1938-49ae-9836-bae28df41408.png)

Second: `Command line configuration`
![image](https://user-images.githubusercontent.com/964610/204858648-ce34b539-fd3c-4166-8949-4937f117afb9.png)

Third `Loaded configuration values` (Dynaconf loaded values, either from env vars (matching `KAFL_`) or config files)
![image](https://user-images.githubusercontent.com/964610/204858816-7277384a-1b76-4732-ba9a-e3d91890b755.png)


And finally the final config after validation:
![image](https://user-images.githubusercontent.com/964610/204858869-3ddb9265-9f5a-4b80-9cda-4a75b520f558.png)
