### PR TITLE
default_settings: set debug value

### DIFF
--- a/kafl_fuzzer/common/config/default_settings.yaml
+++ b/kafl_fuzzer/common/config/default_settings.yaml
@@ -2,6 +2,7 @@
 
 # general options
 work_dir: /dev/shm/kafl_$USER
+debug: false
 processes: 1
 
 # fuzz options


### PR DESCRIPTION
Set a default value for `debug` in configuration files since the validator have not been executed by the time the key is being used in `cmdline.py:hidden()`