### PR TITLE
config: set default values in the config for quiet and verbose

### DIFF
--- a/kafl_fuzzer/common/config/default_settings.yaml
+++ b/kafl_fuzzer/common/config/default_settings.yaml
@@ -3,6 +3,8 @@
 # general options
 work_dir: /dev/shm/kafl_$USER
 debug: false
+quiet: false
+verbose: false
 processes: 1
 
 # fuzz options


### PR DESCRIPTION
`setup_basic_logging()` is checking for these values before the validation happens.
These needs to be set in the default config file