### PR TITLE
config: support existing KAFL_WORKDIR override

### DIFF
--- a/kafl_fuzzer/common/config/cmdline.py
+++ b/kafl_fuzzer/common/config/cmdline.py
@@ -58,7 +58,8 @@ def hidden(msg, unmask=False):
 
 def add_workdir_argument(parser):
     """add the workdir argument to the given parser"""
-    parser.add_argument('-w', '--work-dir', metavar='<dir>', required=False, help='path to the output/working directory.')
+    parser.add_argument('-w', '--workdir', '--work-dir', dest='workdir', metavar='<dir>', required=False,
+                        help='path to the output/working directory.')
 
 # General startup options used by fuzzer, qemu, and/or utilities
 def add_args_general(parser):

--- a/kafl_fuzzer/common/config/default_settings.yaml
+++ b/kafl_fuzzer/common/config/default_settings.yaml
@@ -1,7 +1,7 @@
 # kAFL default configuration
 
 # general options
-work_dir: /dev/shm/kafl_$USER
+workdir: /dev/shm/kafl_$USER
 debug: false
 quiet: false
 verbose: false

--- a/kafl_fuzzer/common/config/settings.py
+++ b/kafl_fuzzer/common/config/settings.py
@@ -7,6 +7,7 @@ from argparse import Namespace
 from appdirs import AppDirs
 from dynaconf import Dynaconf, Validator, ValidationError, loaders, LazySettings
 from dynaconf.utils.boxing import DynaBox
+from dynaconf.utils.functional import empty
 
 from typing import List, Optional, Any
 
@@ -87,8 +88,8 @@ def cast_expand_path(parameter: Any) -> Optional[str]:
     return str(p)
 
 def cast_expand_path_no_verify(parameter: Any) -> Optional[str]:
-    if parameter is None:
-        return None
+    if parameter is empty:
+        return parameter
     exp_str = os.path.expandvars(parameter)
     return exp_str
 

--- a/kafl_fuzzer/common/config/settings.py
+++ b/kafl_fuzzer/common/config/settings.py
@@ -95,7 +95,7 @@ def cast_expand_path_no_verify(parameter: Any) -> Optional[str]:
 # register validators
 settings.validators.register(
     # general
-    Validator("work_dir", must_exist=True, cast=cast_expand_path_no_verify),
+    Validator("workdir", must_exist=True, cast=cast_expand_path_no_verify),
     Validator("purge", default=False, cast=bool),
     Validator("resume", default=False, cast=bool),
     Validator("processes", cast=int),
@@ -159,7 +159,7 @@ settings.validators.register(
     # mcat
     Validator("pack_file"),
     # internal for kAFL
-    Validator("workdir_config", default=lambda config, _validator: str(Path(config.work_dir) / DEFAULT_CONFIG_FILENAME), cast=cast_expand_path_no_verify)
+    Validator("workdir_config", default=lambda config, _validator: str(Path(config.workdir) / DEFAULT_CONFIG_FILENAME), cast=cast_expand_path_no_verify)
 )
 
 def update_from_namespace(namespace: Namespace):

--- a/kafl_fuzzer/common/logger.py
+++ b/kafl_fuzzer/common/logger.py
@@ -54,7 +54,7 @@ def add_logging_file(config: LazySettings):
     assert(LOGGING_CONFIG is not None)
     if config.log:
         # define file handler filepath
-        log_filepath = Path(config.work_dir) / DEBUG_FILENAME
+        log_filepath = Path(config.workdir) / DEBUG_FILENAME
         # define file handler in log_config
         LOGGING_CONFIG['handlers']['file'] = {
             'class': 'logging.FileHandler',

--- a/kafl_fuzzer/common/util.py
+++ b/kafl_fuzzer/common/util.py
@@ -117,8 +117,11 @@ def prepare_working_dir(config):
     try:
         for folder in folders:
             os.makedirs(workdir + folder, exist_ok=resume)
-    except:
+    except FileExistsError:
         logger.error("Refuse to operate on existing workdir, supply either --purge or --resume.")
+        return False
+    except PermissionError as e:
+        logger.error(str(e))
         return False
 
     return True

--- a/kafl_fuzzer/common/util.py
+++ b/kafl_fuzzer/common/util.py
@@ -98,7 +98,7 @@ def find_diffs(data_a, data_b):
 
 def prepare_working_dir(config):
 
-    work_dir   = config.work_dir
+    workdir   = config.workdir
     purge      = config.purge
     resume     = config.resume
 
@@ -112,13 +112,13 @@ def prepare_working_dir(config):
         return False
 
     if purge:
-        shutil.rmtree(work_dir, ignore_errors=True)
+        shutil.rmtree(workdir, ignore_errors=True)
 
     try:
         for folder in folders:
-            os.makedirs(work_dir + folder, exist_ok=resume)
+            os.makedirs(workdir + folder, exist_ok=resume)
     except:
-        logger.error("Refuse to operate on existing work_dir, supply either --purge or --resume.")
+        logger.error("Refuse to operate on existing workdir, supply either --purge or --resume.")
         return False
 
     return True

--- a/kafl_fuzzer/debug/core.py
+++ b/kafl_fuzzer/debug/core.py
@@ -106,8 +106,8 @@ def gdb_session(config, qemu_verbose=True, notifiers=True):
 
 def store_traces(config, qid, basename, exec_hash):
     if config.trace:
-        shutil.move(config.work_dir + f"/pt_trace_dump_{qid}",
-                    config.work_dir + f"/traces/{basename}_{exec_hash}.bin")
+        shutil.move(config.workdir + f"/pt_trace_dump_{qid}",
+                    config.workdir + f"/traces/{basename}_{exec_hash}.bin")
 
 
 def execute_once(config, qemu_verbose=False, notifiers=True):
@@ -442,7 +442,7 @@ def start(settings: LazySettings):
         logger.error("Failed to prepare working directory. Exit.")
         return -1;
 
-    # initialize logger after work_dir purge
+    # initialize logger after workdir purge
     # otherwise the file handler created is removed
     add_logging_file(settings)
     # log config parameters

--- a/kafl_fuzzer/gui/__init__.py
+++ b/kafl_fuzzer/gui/__init__.py
@@ -802,7 +802,7 @@ class GuiData:
 
 
 def main(stdscr):
-    gui = GuiDrawer(settings.work_dir, stdscr)
+    gui = GuiDrawer(settings.workdir, stdscr)
     gui.loop()
 
 

--- a/kafl_fuzzer/manager/bitmap.py
+++ b/kafl_fuzzer/manager/bitmap.py
@@ -27,7 +27,7 @@ class GlobalBitmap:
             GlobalBitmap.bitmap_native_so.are_new_bits_present_do_apply_lut.restype = ctypes.c_uint64
 
         self.bitmap_size = config.bitmap_size
-        self.create_bitmap(name, config.work_dir)
+        self.create_bitmap(name, config.workdir)
         self.c_bitmap = (ctypes.c_uint8 * self.bitmap_size).from_buffer(self.bitmap)
         self.read_only = read_only
         if not read_only:
@@ -38,8 +38,8 @@ class GlobalBitmap:
         for i in range(self.bitmap_size):
             self.c_bitmap[i] = 0
 
-    def create_bitmap(self, name, work_dir):
-        self.bitmap_fd = os.open(work_dir + "/bitmaps/" + name,
+    def create_bitmap(self, name, workdir):
+        self.bitmap_fd = os.open(workdir + "/bitmaps/" + name,
                                  os.O_RDWR | os.O_SYNC | os.O_CREAT)
         os.ftruncate(self.bitmap_fd, self.bitmap_size)
         self.bitmap = mmap.mmap(self.bitmap_fd, self.bitmap_size, mmap.MAP_SHARED, mmap.PROT_WRITE | mmap.PROT_READ)

--- a/kafl_fuzzer/manager/communicator.py
+++ b/kafl_fuzzer/manager/communicator.py
@@ -26,7 +26,7 @@ KAFL_NAMED_SOCKET = '/kafl_socket'
 class ServerConnection:
     def __init__(self, config):
         Listener.fileno = lambda self: self._listener._socket.fileno()
-        self.address = config.work_dir + KAFL_NAMED_SOCKET
+        self.address = config.workdir + KAFL_NAMED_SOCKET
         self.listener = Listener(self.address, 'AF_UNIX', backlog=1000)
         self.clients = [self.listener]
         self.clients_seen = 0
@@ -66,7 +66,7 @@ class ServerConnection:
 class ClientConnection:
     def __init__(self, pid, config):
         self.pid = pid
-        self.address = config.work_dir + KAFL_NAMED_SOCKET
+        self.address = config.workdir + KAFL_NAMED_SOCKET
         self.sock = self.connect()
 
     def connect(self):

--- a/kafl_fuzzer/manager/core.py
+++ b/kafl_fuzzer/manager/core.py
@@ -53,7 +53,7 @@ def start(settings: LazySettings):
     if not self_check():
         return 1
 
-    work_dir   = settings.work_dir
+    workdir   = settings.workdir
     seed_dir   = settings.seed_dir
     num_worker = settings.processes
 
@@ -65,12 +65,12 @@ def start(settings: LazySettings):
         logger.error("Failed to prepare working directory. Exit.")
         return -1;
 
-    # initialize logger after work_dir purge
+    # initialize logger after workdir purge
     # otherwise the file handler created is removed
     add_logging_file(settings)
 
     if seed_dir:
-        if not copy_seed_files(work_dir, seed_dir):
+        if not copy_seed_files(workdir, seed_dir):
             logger.error("Error when importing seeds. Exit.")
             return 1
     else:

--- a/kafl_fuzzer/manager/manager.py
+++ b/kafl_fuzzer/manager/manager.py
@@ -59,7 +59,7 @@ class ManagerTask:
     def send_next_task(self, conn):
         # Inputs placed to imports/ folder have priority.
         # This can also be used to inject additional seeds at runtime.
-        imports = glob.glob(self.config.work_dir + "/imports/*")
+        imports = glob.glob(self.config.workdir + "/imports/*")
         if imports:
             path = imports.pop()
             logger.debug("Importing payload from %s" % path)
@@ -140,7 +140,7 @@ class ManagerTask:
 
     def store_trace(self, node, tmp_trace):
         if tmp_trace and os.path.exists(tmp_trace):
-            trace_dump_out = "%s/traces/fuzz_%05d.bin" % (self.config.work_dir, node.get_id())
+            trace_dump_out = "%s/traces/fuzz_%05d.bin" % (self.config.workdir, node.get_id())
             with open(tmp_trace, 'rb') as f_in:
                 with lz4.LZ4FrameFile(trace_dump_out + ".lz4", 'wb',
                         compression_level=lz4.COMPRESSIONLEVEL_MINHC) as f_out:

--- a/kafl_fuzzer/manager/node.py
+++ b/kafl_fuzzer/manager/node.py
@@ -19,7 +19,7 @@ class QueueNode:
     def __init__(self, config, payload, bitmap, node_struct, write=True):
         self.node_struct = node_struct
         self.busy = False
-        self.workdir = config.work_dir
+        self.workdir = config.workdir
 
         self.set_id(QueueNode.NextID, write=False)
         QueueNode.NextID += 1

--- a/kafl_fuzzer/manager/statistics.py
+++ b/kafl_fuzzer/manager/statistics.py
@@ -26,7 +26,7 @@ class ManagerStatistics:
         self.write_thres = 0.5
         self.quiet = config.quiet
         self.num_workers = config.processes
-        self.work_dir = config.work_dir
+        self.workdir = config.workdir
         self.data = {
                 "start_time": time.time(),
                 "total_execs": 0,
@@ -53,15 +53,15 @@ class ManagerStatistics:
                 "num_workers": self.num_workers
                 }
 
-        self.stats_file = self.work_dir + "/stats"
-        self.plot_file  = self.work_dir + "/stats.csv"
+        self.stats_file = self.workdir + "/stats"
+        self.plot_file  = self.workdir + "/stats.csv"
         # write once so that we have a valid stats file
         self.write_plot_header()
         self.maybe_write_stats()
 
     def read_worker_stats(self, pid):
         # one-shot attempt to read + parse file - this can fail!
-        filename = self.work_dir + "/worker_stats_%d" % pid
+        filename = self.workdir + "/worker_stats_%d" % pid
         return msgpack.unpackb(read_binary_file(filename), strict_map_key=False)
 
     def event_queue_cycle(self, queue):
@@ -241,7 +241,7 @@ class ManagerStatistics:
 
 class WorkerStatistics:
     def __init__(self, pid, config):
-        self.filename = "%s/worker_stats_%d" % (config.work_dir, pid)
+        self.filename = "%s/worker_stats_%d" % (config.workdir, pid)
         self.write_last = 0
         self.write_thres = 0.5
         self.execs_new = 0

--- a/kafl_fuzzer/plot/__init__.py
+++ b/kafl_fuzzer/plot/__init__.py
@@ -56,7 +56,7 @@ class Graph:
             for nodefile in sorted(glob.glob(self.workdir + "/metadata/node_*")):
                 self.__process_node(nodefile)
         except:
-            logger.error("Error processing stats at given work_dir %s. Aborting." % repr(self.workdir))
+            logger.error("Error processing stats at given workdir %s. Aborting." % repr(self.workdir))
             raise
 
         if self.outfile:
@@ -136,8 +136,8 @@ class Graph:
 def start(settings: LazySettings):
     print_banner("kAFL Plotter")
 
-    if glob.glob(settings.work_dir + "/worker_stats_*") == []:
-        logging.warn("No kAFL statistics found in %s. Invalid workdir?", settings.work_dir)
+    if glob.glob(settings.workdir + "/worker_stats_*") == []:
+        logging.warn("No kAFL statistics found in %s. Invalid workdir?", settings.workdir)
 
-    dot = Graph(settings.work_dir, settings.outfile)
+    dot = Graph(settings.workdir, settings.outfile)
     dot.process_once()

--- a/kafl_fuzzer/technique/havoc.py
+++ b/kafl_fuzzer/technique/havoc.py
@@ -35,7 +35,7 @@ def init_havoc(config):
         append_handler(havoc_dict_insert)
         append_handler(havoc_dict_replace)
 
-    location_corpus = config.work_dir + "/corpus/"
+    location_corpus = config.workdir + "/corpus/"
 
 
 def havoc_range(perf_score):

--- a/kafl_fuzzer/technique/radamsa.py
+++ b/kafl_fuzzer/technique/radamsa.py
@@ -24,9 +24,9 @@ def init_radamsa(config, pid):
     global input_dir
     global radamsa_path
 
-    corpus_dir = config.work_dir + "/corpus/"
+    corpus_dir = config.workdir + "/corpus/"
     radamsa_path = config.radamsa_path
-    input_dir = config.work_dir + "/radamsa_%d/" % pid
+    input_dir = config.workdir + "/radamsa_%d/" % pid
 
     if not os.path.isdir(input_dir):
         os.makedirs(input_dir)

--- a/kafl_fuzzer/technique/redqueen/workdir.py
+++ b/kafl_fuzzer/technique/redqueen/workdir.py
@@ -13,7 +13,7 @@ import shutil
 
 class RedqueenWorkdir:
     def __init__(self, qemu_id, config):
-        self.base_path = config.work_dir + "/redqueen_workdir_" + str(qemu_id)
+        self.base_path = config.workdir + "/redqueen_workdir_" + str(qemu_id)
 
     def init_dir(self):
         if os.path.exists(self.base_path):

--- a/kafl_fuzzer/worker/qemu.py
+++ b/kafl_fuzzer/worker/qemu.py
@@ -52,25 +52,25 @@ class qemu:
         self.control = None
         self.persistent_runs = 0
 
-        work_dir = self.config.work_dir
+        workdir = self.config.workdir
 
-        self.qemu_aux_buffer_filename = work_dir + "/aux_buffer_%d" % self.pid
+        self.qemu_aux_buffer_filename = workdir + "/aux_buffer_%d" % self.pid
 
-        self.bitmap_filename = work_dir + "/bitmap_%d" % self.pid
-        self.ijonmap_filename = work_dir + "/ijon_%d" % self.pid
-        self.payload_filename = work_dir + "/payload_%d" % self.pid
-        self.control_filename = work_dir + "/interface_%d" % self.pid
-        self.qemu_trace_log = work_dir + "/qemu_trace_%02d.log" % self.pid
-        self.serial_logfile = work_dir + "/serial_%02d.log" % self.pid
+        self.bitmap_filename = workdir + "/bitmap_%d" % self.pid
+        self.ijonmap_filename = workdir + "/ijon_%d" % self.pid
+        self.payload_filename = workdir + "/payload_%d" % self.pid
+        self.control_filename = workdir + "/interface_%d" % self.pid
+        self.qemu_trace_log = workdir + "/qemu_trace_%02d.log" % self.pid
+        self.serial_logfile = workdir + "/serial_%02d.log" % self.pid
         self.hprintf_log = self.config.log_hprintf or self.config.log_crashes
-        self.hprintf_logfile = work_dir + "/hprintf_%02d.log" % self.pid
+        self.hprintf_logfile = workdir + "/hprintf_%02d.log" % self.pid
 
         self.redqueen_workdir = RedqueenWorkdir(self.pid, config)
         self.redqueen_workdir.init_dir()
 
         if not resume:
             for page_cache_ext in ["lock", "dump", "addr"]:
-                with open(self.config.work_dir + "/page_cache." + page_cache_ext, 'w') as f:
+                with open(self.config.workdir + "/page_cache." + page_cache_ext, 'w') as f:
                     f.truncate(0)
 
         self.starved = False
@@ -80,7 +80,7 @@ class qemu:
         self.cmd = self.config.qemu_base
         self.cmd += " -chardev socket,server,id=nyx_socket,path=" + self.control_filename + \
                     " -device nyx,chardev=nyx_socket" + \
-                    ",workdir=" + work_dir + \
+                    ",workdir=" + workdir + \
                     ",worker_id=%d" % self.pid + \
                     ",bitmap_size=" + str(self.bitmap_size) + \
                     ",input_buffer_size=" + str(self.payload_size)
@@ -138,7 +138,7 @@ class qemu:
 
         # Fast VM snapshot configuration
         self.cmd.append("-fast_vm_reload")
-        snapshot_path = work_dir + "/snapshot/"
+        snapshot_path = workdir + "/snapshot/"
 
         if pid == 0 or pid == 1337 and not resume:
             # boot and create snapshot
@@ -346,7 +346,7 @@ class qemu:
         if self.hprintf_log and os.path.exists(self.hprintf_logfile):
             if os.path.getsize(self.hprintf_logfile) > 0:
                 shutil.copy(self.hprintf_logfile, "%s/logs/%s_%s.log" % (
-                    self.config.work_dir, label[:5], stamp[:6]))
+                    self.config.workdir, label[:5], stamp[:6]))
                 os.truncate(self.hprintf_logfile, 0)
 
     def flush_crashlogs(self):

--- a/kafl_fuzzer/worker/worker.py
+++ b/kafl_fuzzer/worker/worker.py
@@ -80,8 +80,8 @@ class WorkerTask:
         self.conn.send_ready()
 
     def handle_node(self, msg):
-        meta_data = QueueNode.get_metadata(self.config.work_dir, msg["task"]["nid"])
-        payload = QueueNode.get_payload(self.config.work_dir, meta_data)
+        meta_data = QueueNode.get_metadata(self.config.workdir, msg["task"]["nid"])
+        payload = QueueNode.get_payload(self.config.workdir, meta_data)
 
         # fixme: determine globally based on all seen regulars
         t_dyn = self.t_soft + 1.2 * meta_data["info"]["performance"]
@@ -210,7 +210,7 @@ class WorkerTask:
 
     def store_funky(self, data):
         # store funky input for further analysis 
-        filename = f"%s/funky/payload_%04x%02x" % (self.config.work_dir, self.num_funky, self.pid)
+        filename = f"%s/funky/payload_%04x%02x" % (self.config.workdir, self.num_funky, self.pid)
         atomic_write(filename, data)
         self.num_funky += 1
 
@@ -256,10 +256,10 @@ class WorkerTask:
         # This is generally slower and produces different bitmaps so we execute it in
         # a different phase as part of calibration stage.
         # Optionally pickup pt_trace_dump* files as well in case both methods are enabled.
-        trace_edge_in = self.config.work_dir + "/redqueen_workdir_%d/pt_trace_results.txt" % self.pid
-        trace_dump_in = self.config.work_dir + "/pt_trace_dump_%d" % self.pid
-        trace_edge_out = self.config.work_dir + "/traces/fuzz_cb_%05d.lst" % info['id']
-        trace_dump_out = self.config.work_dir + "/traces/fuzz_cb_%05d.bin" % info['id']
+        trace_edge_in = self.config.workdir + "/redqueen_workdir_%d/pt_trace_results.txt" % self.pid
+        trace_dump_in = self.config.workdir + "/pt_trace_dump_%d" % self.pid
+        trace_edge_out = self.config.workdir + "/traces/fuzz_cb_%05d.lst" % info['id']
+        trace_dump_out = self.config.workdir + "/traces/fuzz_cb_%05d.bin" % info['id']
 
         self.logger.info("Tracing payload_%05d..", info['id'])
 
@@ -368,9 +368,9 @@ class WorkerTask:
                     exec_res.performance = (exec_res.performance + runtime)/2
 
                 if trace_pt and stable:
-                    trace_in = "%s/pt_trace_dump_%d" % (self.config.work_dir, self.pid)
+                    trace_in = "%s/pt_trace_dump_%d" % (self.config.workdir, self.pid)
                     if os.path.exists(trace_in):
-                        with tempfile.NamedTemporaryFile(delete=False,dir=self.config.work_dir + "/traces") as f:
+                        with tempfile.NamedTemporaryFile(delete=False,dir=self.config.workdir + "/traces") as f:
                             shutil.move(trace_in, f.name)
                             info['pt_dump'] = f.name
                 if not stable:


### PR DESCRIPTION
I think we want to suport the existing KAFL_WORKDIR variable used in several scripts + docs so far. It is at odds with the --work-dir argument but they are established now and actually easier to type than KAFL_WORK_DIR.

I tried the previous proposed option:
>    Validator("workdir", must_exist=True, cast=cast_expand_path_no_verify),
 >   Validator("work_dir", must_exist=True, default=lambda config, _validator: config.workdir),

However, the default= action is only called if the option was not set. There seem to be no other available API hooks so we cannot easily create an alias like this.

So this patch replaces all instances of work_dir with workdir.  argparse -w --work-dir options now set the workdir variable, and they got an additional alias --workdir so there is a path to make this consistent in the future.