### PR TITLE
util: skip QEMU sweep when running inside container

### DIFF
--- a/kafl_fuzzer/common/util.py
+++ b/kafl_fuzzer/common/util.py
@@ -8,7 +8,6 @@ import shutil
 import sys
 import tempfile
 import string
-import getpass
 import logging
 from shutil import copyfile
 
@@ -29,13 +28,10 @@ class Singleton(type):
 
 # print any qemu-like processes owned by this user
 def qemu_sweep(msg):
-    def get_qemu_processes():
-        for proc in psutil.process_iter(['pid', 'name', 'username']):
-            if proc.info['username'] == getpass.getuser():
-                if 'qemu-system-x86_64' in proc.info['name']:
-                    yield (proc.info['pid'])
-
-    pids = [ p for p in get_qemu_processes() ]
+    pids = [
+        p.info['pid'] for p in psutil.process_iter(['pid', 'name', 'uids'])
+        if p.info['name'] == 'qemu-system-x86_64' and p.info['uids'].real == os.getuid()
+    ]
 
     if (len(pids) > 0):
         logger.warn(msg + " " + repr(pids))


### PR DESCRIPTION
Avoid these types of errors:
~~~python
qemu-system-x86_64: terminating on signal 15 from pid 12 (kafl)
Traceback (most recent call last):
  File "stub.py", line 2, in <module>
  File "kafl_fuzzer/__main__.py", line 34, in main
  File "kafl_fuzzer/manager/core.py", line 114, in start
  File "kafl_fuzzer/common/util.py", line 38, in qemu_sweep
  File "kafl_fuzzer/common/util.py", line 38, in <listcomp>
  File "kafl_fuzzer/common/util.py", line 34, in get_qemu_processes
  File "getpass.py", line 169, in getuser
KeyError: 'getpwuid(): uid not found: 2009'
~~~

related to https://github.com/IntelLabs/kAFL/pull/104