### PR TITLE
Fix/dynaconf validator

### DIFF
--- a/.github/RELEASE.md
+++ b/.github/RELEASE.md
@@ -23,6 +23,7 @@
 
 - avoid Qemu hang when handling ABORT in pre-init phase (#34)
 - fix including `default_settings.yaml` in the final package (#35)
+- remove dynaconf validation workaround (#60)
 
 # 📖 Documentation
 

--- a/kafl_fuzzer/common/config/settings.py
+++ b/kafl_fuzzer/common/config/settings.py
@@ -151,7 +151,7 @@ settings.validators.register(
     Validator("trace", default=False, cast=bool),
     Validator("trace_cb", default=False, cast=bool),
     # debug
-    Validator("input", default=lambda config, _validator: config.workdir, cast=cast_expand_path),
+    Validator("input", default=lambda config, _validator: config.workdir, cast=cast_expand_path_no_verify),
     Validator("iterations", cast=int),
     Validator("action", is_in=VALID_DEBUG_ACTIONS),
     Validator("ptdump_path", default=None, cast=cast_expand_path),

--- a/kafl_fuzzer/common/config/settings.py
+++ b/kafl_fuzzer/common/config/settings.py
@@ -1,10 +1,8 @@
 import os
-import sys
 import re
 from contextlib import suppress
 from pathlib import Path
 from argparse import Namespace
-import logging
 
 from appdirs import AppDirs
 from dynaconf import Dynaconf, Validator, ValidationError, loaders, LazySettings
@@ -178,27 +176,10 @@ def update_from_namespace(namespace: Namespace):
     # update dynaconf settings
     settings.update(dict_namespace)
 
-
 def validate():
-    """Validate Dynaconf configuration.
-
-    the settings.validators.validate() function cannot be relied upon because of a bug in Dynaconf."""
+    """Validate Dynaconf configuration."""
     global settings
-
-    logger = logging.getLogger(__name__)
-    try:
-        settings.validators.validate()
-    except ValidationError as e:
-        logger.critical("Configuration error: %s", str(e))
-        sys.exit(1)
-    # workaround Dynaconf bug
-    # https://github.com/dynaconf/dynaconf/issues/834
-    for validator in settings.validators:
-        cast_func = validator.cast
-        try:
-            settings[validator.names[0]] = cast_func(settings[validator.names[0]])
-        except KeyError:
-            pass
+    settings.validators.validate()
 
 def dump_config():
     """Dump current configuration in workdir config file"""

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,6 @@ inotify
 msgpack
 tqdm
 six
-dynaconf
+dynaconf==3.1.12
 appdirs
 PyYAML==6.0


### PR DESCRIPTION
Following https://github.com/dynaconf/dynaconf/releases/tag/3.1.12
This PR removes the validation workaround that we put in place because of https://github.com/dynaconf/dynaconf/issues/834