### PR TITLE
config: remove qemu_append from default_settings

### DIFF
--- a/.github/RELEASE.md
+++ b/.github/RELEASE.md
@@ -24,6 +24,7 @@
 - avoid Qemu hang when handling ABORT in pre-init phase (#34)
 - fix including `default_settings.yaml` in the final package (#35)
 - remove dynaconf validation workaround (#60)
+- remove `qemu_append` value from `default_settings.yaml` (#63)
 
 # 📖 Documentation
 

--- a/kafl_fuzzer/common/config/default_settings.yaml
+++ b/kafl_fuzzer/common/config/default_settings.yaml
@@ -24,6 +24,5 @@ ptdump_path: $LIBXDC_ROOT/build/ptdump_static
 radamsa_path: $RADAMSA_ROOT/bin/radamsa
 # default qemu configuration
 qemu_base: -enable-kvm -machine kAFL64-v1 -cpu kAFL64-Hypervisor-v1,+vmx -no-reboot -net none -display none
-qemu_append: nokaslr oops=panic nopti mitigations=off console=ttyS0
 qemu_serial: -device isa-serial,chardev=kafl_serial
 qemu_memory: 256


### PR DESCRIPTION
This setting is specific for kernel fuzzing, and should only be present in https://github.com/IntelLabs/kafl.targets/blob/master/linux-kernel/kafl_config.yaml
Raised by @miki-intel-work