### PR TITLE
settings: don't force qemu_image to be a path

### DIFF
--- a/.github/RELEASE.md
+++ b/.github/RELEASE.md
@@ -1,34 +1,18 @@
 # 🌟 Features
+/
 
 # ✨ Improvements
 
-- refactor kafl command-line with subcommands (#22)
-    - move kafl scripts into a single kafl entrypoint:
-        - `kafl_fuzz.py`    -> `kafl fuzz`
-        - `kafl_debug.py`   -> `kafl debug`
-        - `kafl_cov.py`     -> `kafl cov`
-        - `kafl_plot.py`    -> `kalf plot`
-        - `kafl_gui.py`     -> `kafl gui`
-        - `scripts/mcat.py` -> `kafl mcat`
-    - option `--afl-skip-ranges` has been removed (never used anyway)
-    - removed config override via `$PWD/kafl.yaml` (not explicit, users don't expect that behavior)
-    - rename and reformat `$WORKDIR/config` (MessagePack) -> `$WORKDIR/config.yaml` (YAML)
-- add early logging of fuzzer loaded configuration before validation (#38)
-    - deprecate `KAFL_CONFIG_DEBUG`
-- remove `pygraphviz` dependency (#43)
-- `input` config key will default to the `workdir` value (#58)
-    - no need to specify `kafl cov --input $KAFL_WORKDIR` anymore
+/
 
 # 🔧 Fixes
 
-- avoid Qemu hang when handling ABORT in pre-init phase (#34)
-- fix including `default_settings.yaml` in the final package (#35)
-- remove dynaconf validation workaround (#60)
-- fix appdirs import (#61)
+- disable checking whether `qemu_image` value exists (#65)
 
 # 📖 Documentation
 
-- add `docs/fuzzer_configuration.md` to document new configuration management based on Dynaconf (#22)
+/
 
 # 🧰 Behind the scenes
 
+/

--- a/kafl_fuzzer/common/config/settings.py
+++ b/kafl_fuzzer/common/config/settings.py
@@ -127,7 +127,7 @@ settings.validators.register(
     Validator("kickstart", cast=int),
     Validator("radamsa_path", default=None, cast=cast_expand_path),
     # qemu
-    Validator("qemu_image", default=None, cast=cast_expand_path),
+    Validator("qemu_image", default=None),
     Validator("qemu_snapshot", default=None, cast=cast_expand_path),
     Validator("qemu_bios", default=None, cast=cast_expand_path),
     Validator("qemu_kernel", default=None, cast=cast_expand_path),


### PR DESCRIPTION
This PR removes the Path checking on `qemu_image` parameter.

In fact, this parameter can be a complex drive description, and not just a file as we assumed.
For example, If I want to specify a qcow image that should be attached with the `virtio` interface:
`--image /home/user/myqemyimage.qcow2,if=virtio`

Without the fix:
```python
Traceback (most recent call last):
  File "/home/mtarral/kafl/kafl/.venv/bin/kafl", line 11, in <module>
    load_entry_point('kafl-fuzzer', 'console_scripts', 'kafl')()
  File "/home/mtarral/kafl/kafl/fuzzer/kafl_fuzzer/__main__.py", line 30, in main
    validate()
  File "/home/mtarral/kafl/kafl/fuzzer/kafl_fuzzer/common/config/settings.py", line 184, in validate
    settings.validators.validate()
  File "/home/mtarral/kafl/kafl/.venv/lib/python3.8/site-packages/dynaconf/validator.py", line 467, in validate
    validator.validate(
  File "/home/mtarral/kafl/kafl/.venv/lib/python3.8/site-packages/dynaconf/validator.py", line 213, in validate
    self._validate_items(
  File "/home/mtarral/kafl/kafl/.venv/lib/python3.8/site-packages/dynaconf/validator.py", line 290, in _validate_items
    value = self.cast(settings.get(name))
  File "/home/mtarral/kafl/kafl/fuzzer/kafl_fuzzer/common/config/settings.py", line 87, in cast_expand_path
    raise FileNotFoundError(f"Path {p} doesn't exist")
FileNotFoundError: Path /home/mtarral/.local/share/libvirt/images/windows_x86_64-userspace_vagrant-kafl-windows.img,if=virtio doesn't exist
```

