### PR TITLE
Parse range submit

### DIFF
--- a/kafl_fuzzer/common/config/settings.py
+++ b/kafl_fuzzer/common/config/settings.py
@@ -200,8 +200,14 @@ def dump_config():
     # dump to a file, format is infered by file extension
     loaders.write(settings.workdir_config, DynaBox(config).to_dict())
 
-def load_config() -> LazySettings:
-    """Load an additional configuration file with Dynaconf and returns the settings object"""
+def load_config(keys: Optional[List[str]]) -> LazySettings:
+    """Load an additional configuration file with Dynaconf and returns the settings object
+    
+    keys: only load the specified keys"""
     global settings
-    settings.load_file(settings.workdir_config, silent=False, validate=True)
+    if keys is None:
+        settings.load_file(settings.workdir_config, silent=False, validate=True)
+    else:
+        for k in keys:
+            settings.load_file(settings.workdir_config, key=k, silent=False, validate=True)
     return settings

--- a/kafl_fuzzer/common/config/settings.py
+++ b/kafl_fuzzer/common/config/settings.py
@@ -70,6 +70,9 @@ def cast_ip_range_to_list(parameter: Any) -> Optional[List[int]]:
     """Checks that a given IP range string is valid and returns a List of that range"""
     if parameter is None:
         return None
+    if isinstance(parameter, list):
+        # revalidation triggered, already a list
+        return parameter
     m = re.match(r"([(0-9abcdef]{1,16})(?:-([0-9abcdef]{1,16}))?$", parameter.replace("0x", "").lower())
     if not m:
         raise ValueError(f"{parameter}: invalid range specified: not a number")
@@ -200,5 +203,5 @@ def dump_config():
 def load_config() -> LazySettings:
     """Load an additional configuration file with Dynaconf and returns the settings object"""
     global settings
-    settings.load_file(settings.workdir_config, silent=False)
+    settings.load_file(settings.workdir_config, silent=False, validate=True)
     return settings

--- a/kafl_fuzzer/common/config/settings.py
+++ b/kafl_fuzzer/common/config/settings.py
@@ -20,6 +20,9 @@ VALID_DEBUG_ACTIONS = ["benchmark", "gdb", "trace", "single", "trace-qemu", "noi
 
 # default internal to kAFL
 DEFAULT_CONFIG_FILENAME = "config.yaml"
+WORKDIR_SNAPSHOT_DIRNAME = "snapshot"
+DEFAULT_CONFIG_SNAPSHOT_META_FILENAME = "state.yaml"
+INTEL_PT_MAX_RANGES = 4
 APPDIRS = AppDirs(APPNAME)
 
 
@@ -92,7 +95,9 @@ def cast_expand_path_no_verify(parameter: Any) -> Optional[str]:
     if parameter is empty:
         return parameter
     exp_str = os.path.expandvars(parameter)
-    return exp_str
+    # ensure absolute path
+    abs_path = Path(exp_str).resolve()
+    return str(abs_path)
 
 # register validators
 settings.validators.register(
@@ -162,7 +167,8 @@ settings.validators.register(
     # mcat
     Validator("pack_file"),
     # internal for kAFL
-    Validator("workdir_config", default=lambda config, _validator: str(Path(config.workdir) / DEFAULT_CONFIG_FILENAME), cast=cast_expand_path_no_verify)
+    Validator("workdir_config", default=lambda config, _validator: str(Path(config.workdir) / DEFAULT_CONFIG_FILENAME), cast=cast_expand_path_no_verify),
+    Validator("workdir_snap_state_meta", default=lambda config, _validator: str(Path(config.workdir) / WORKDIR_SNAPSHOT_DIRNAME / DEFAULT_CONFIG_SNAPSHOT_META_FILENAME), cast=cast_expand_path_no_verify)
 )
 
 def update_from_namespace(namespace: Namespace):
@@ -194,5 +200,5 @@ def dump_config():
 def load_config() -> LazySettings:
     """Load an additional configuration file with Dynaconf and returns the settings object"""
     global settings
-    settings.load_file(settings.workdir_config)
+    settings.load_file(settings.workdir_config, silent=False)
     return settings

--- a/kafl_fuzzer/common/logger.py
+++ b/kafl_fuzzer/common/logger.py
@@ -9,7 +9,6 @@ import logging
 from logging import LoggerAdapter
 from pathlib import Path
 from logging.config import dictConfig
-from pprint import pformat
 
 import kafl_fuzzer
 
@@ -67,8 +66,5 @@ def add_logging_file(config: LazySettings):
         LOGGING_CONFIG['root']['handlers'].append('file')
         # configure logging
         dictConfig(LOGGING_CONFIG)
-    # dump final logger config
-    logging.debug('Logger configuration:')
-    logging.debug(pformat(LOGGING_CONFIG))
 
 load_logging_config()

--- a/kafl_fuzzer/coverage/__init__.py
+++ b/kafl_fuzzer/coverage/__init__.py
@@ -37,6 +37,7 @@ from kafl_fuzzer.common.logger import add_logging_file
 from kafl_fuzzer.common.util import prepare_working_dir, read_binary_file, qemu_sweep, print_banner
 from kafl_fuzzer.worker.execution_result import ExecutionResult
 from kafl_fuzzer.worker.qemu import qemu
+from kafl_fuzzer.common.config import load_config
 
 import csv
 
@@ -475,6 +476,13 @@ def start(settings: LazySettings):
     global null_hash
 
     print_banner("kAFL Coverage Analyzer")
+
+    # load additional config file from workdir
+    # (in order to get IPx settings generated during fuzz run)
+    try:
+        load_config()
+    except FileNotFoundError:
+        logging.debug("Unable to load workdir kAFL config")
 
     if not self_check():
         return -1

--- a/kafl_fuzzer/coverage/__init__.py
+++ b/kafl_fuzzer/coverage/__init__.py
@@ -38,6 +38,7 @@ from kafl_fuzzer.common.util import prepare_working_dir, read_binary_file, qemu_
 from kafl_fuzzer.worker.execution_result import ExecutionResult
 from kafl_fuzzer.worker.qemu import qemu
 from kafl_fuzzer.common.config import load_config
+from kafl_fuzzer.common.config.settings import INTEL_PT_MAX_RANGES
 
 import csv
 
@@ -479,8 +480,9 @@ def start(settings: LazySettings):
 
     # load additional config file from workdir
     # (in order to get IPx settings generated during fuzz run)
+    pt_ip_keys = [f'ip{i}' for i in range(INTEL_PT_MAX_RANGES)]
     try:
-        load_config()
+        load_config(pt_ip_keys)
     except FileNotFoundError:
         logging.debug("Unable to load workdir kAFL config")
 

--- a/kafl_fuzzer/manager/manager.py
+++ b/kafl_fuzzer/manager/manager.py
@@ -101,10 +101,9 @@ class ManagerTask:
                         self.queue.update_node_results(msg["node_id"], msg["results"], None)
                 elif msg["type"] == MSG_NEW_INPUT:
                     # Worker reports new interesting input
-                    if self.config.debug:
-                        logger.debug("Received new input (exit=%s): %s" % (
-                           msg["input"]["info"]["exit_reason"],
-                           repr(msg["input"]["payload"][:24])))
+                    logger.debug("Received new input (exit=%s): %s" % (
+                       msg["input"]["info"]["exit_reason"],
+                       repr(msg["input"]["payload"][:24])))
                     self.maybe_insert_node(msg["input"]["payload"], msg["input"]["bitmap"], msg["input"]["info"])
                 elif msg["type"] == MSG_READY:
                     # Worker is ready for new input (initial hello or import done)

--- a/kafl_fuzzer/worker/qemu.py
+++ b/kafl_fuzzer/worker/qemu.py
@@ -24,6 +24,7 @@ from kafl_fuzzer.worker.execution_result import ExecutionResult
 from kafl_fuzzer.worker.qemu_aux_buffer import QemuAuxBuffer
 from kafl_fuzzer.worker.qemu_aux_buffer import QemuAuxRC as RC
 from kafl_fuzzer.common.logger import WorkerLogAdapter
+from kafl_fuzzer.common.config.settings import INTEL_PT_MAX_RANGES
 
 class QemuIOException(Exception):
         """Exception raised when Qemu interaction fails"""
@@ -92,11 +93,10 @@ class qemu:
         if self.config.sharedir:
             self.cmd += ",sharedir=" + self.config.sharedir
 
-        for i in range(4):
-            key = "ip" + str(i)
-            if getattr(config, key, None):
-                range_a = hex(getattr(config, key)[0]).replace("L", "")
-                range_b = hex(getattr(config, key)[1]).replace("L", "")
+        for i in range(INTEL_PT_MAX_RANGES):
+            if self.config[f"ip{i}"]:
+                range_a = hex(self.config[f"ip{i}"][0]).replace("L", "")
+                range_b = hex(self.config[f"ip{i}"][1]).replace("L", "")
                 self.cmd += ",ip" + str(i) + "_a=" + range_a + ",ip" + str(i) + "_b=" + range_b
 
         self.cmd = [_f for _f in self.cmd.split(" ") if _f]

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,6 @@ inotify
 msgpack
 tqdm
 six
-dynaconf==3.1.12
+dynaconf==3.2.0
 appdirs
 PyYAML==6.0


### PR DESCRIPTION
This PR parses the range submit info dumped by https://github.com/IntelLabs/kafl.qemu/pull/10 on fuzzer shutdown.

It then updates his own configuration and dumps it the known `WORKDIR/config.yaml` config file.

`kafl cov` has been updated to load this additional config file at startup, and only refresh its IP filters config.

This allows to transparently launch `kafl cov` on an existing workdir, and removes manual user configuration, and dumping unstructured data through hprintf logs.