### PR TITLE
config: move action as required argument for debug subcommand only

### DIFF
--- a/.github/RELEASE.md
+++ b/.github/RELEASE.md
@@ -8,6 +8,7 @@
 # 🔧 Fixes
 
 - disable checking whether `qemu_image` value exists (#65)
+- config: move action as required argument for debug subcommand only (#71)
 
 # 📖 Documentation
 

--- a/kafl_fuzzer/common/config/cmdline.py
+++ b/kafl_fuzzer/common/config/cmdline.py
@@ -147,7 +147,6 @@ def add_args_qemu(parser):
 def add_args_debug(parser):
     parser.add_argument('--input', metavar='<file/dir>', help='path to input file or workdir.')
     parser.add_argument('-n', '--iterations', metavar='<n>', help='execute <n> times (for some actions)')
-    parser.add_argument('--action', required=False, metavar='<cmd>', help=DEBUG_MODES_HELP)
     parser.add_argument('--ptdump-path', required=False, metavar='<file>', help=hidden('path to ptdump executable'))
 
 
@@ -191,6 +190,8 @@ class ConfigParserBuilder():
 
         debug_grp = debug_subcommand.add_argument_group("Debug options")
         add_args_debug(debug_grp)
+        # add "action" argument, only for "debug" subcommand
+        debug_grp.add_argument('--action', required=True, metavar='<cmd>', help=DEBUG_MODES_HELP)
 
         qemu_grp = debug_subcommand.add_argument_group('Qemu/Nyx options')
         add_args_qemu(qemu_grp)

--- a/kafl_fuzzer/common/config/settings.py
+++ b/kafl_fuzzer/common/config/settings.py
@@ -161,6 +161,7 @@ settings.validators.register(
     Validator("trace", default=False, cast=bool),
     Validator("trace_cb", default=False, cast=bool),
     # debug
+    Validator("action"),
     Validator("input", default=lambda config, _validator: config.workdir, cast=cast_expand_path_no_verify),
     Validator("iterations", cast=int),
     Validator("action", is_in=VALID_DEBUG_ACTIONS),


### PR DESCRIPTION
The `action` argument is only used by the `debug` subcommand.
Furthermore, it's a required argument that should be constrained by the command line when invoking the `debug` subcommand.

This PR updates the cmdline parser so that the `action` argument will only be added to the `debug` options subgroup.

kafl cov --help:
![image](https://github.com/IntelLabs/kafl.fuzzer/assets/964610/2473cbd2-83ce-42b3-a558-9b7a0a4181a0)


kafl debug --help:
![image](https://github.com/IntelLabs/kafl.fuzzer/assets/964610/921a96d9-77be-46eb-bb7e-78d8e945982a)


kafl debug:
![image](https://github.com/IntelLabs/kafl.fuzzer/assets/964610/66b49bea-e34d-496c-88aa-91c663eef8f5)
