### PR TITLE
config: set qemu_append only when qemu_kernel is defined

### DIFF
--- a/kafl_fuzzer/common/config/default_settings.yaml
+++ b/kafl_fuzzer/common/config/default_settings.yaml
@@ -24,6 +24,6 @@ ptdump_path: $LIBXDC_ROOT/build/ptdump_static
 radamsa_path: $RADAMSA_ROOT/bin/radamsa
 # default qemu configuration
 qemu_base: -enable-kvm -machine kAFL64-v1 -cpu kAFL64-Hypervisor-v1,+vmx -no-reboot -net none -display none
-qemu_append: nokaslr oops=panic nopti mitigations=off console=ttyS0
+qemu_append_default: nokaslr oops=panic nopti mitigations=off console=ttyS0
 qemu_serial: -device isa-serial,chardev=kafl_serial
 qemu_memory: 256

--- a/kafl_fuzzer/common/config/settings.py
+++ b/kafl_fuzzer/common/config/settings.py
@@ -140,6 +140,7 @@ settings.validators.register(
     Validator("qemu_bios", default=None, cast=cast_expand_path),
     Validator("qemu_kernel", default=None, cast=cast_expand_path),
     Validator("qemu_initrd", default=None, cast=cast_expand_path),
+    Validator("qemu_append_default", default=None),
     Validator("qemu_append", default=None),
     Validator("qemu_memory", cast=int),
     Validator("qemu_base"),

--- a/kafl_fuzzer/worker/qemu.py
+++ b/kafl_fuzzer/worker/qemu.py
@@ -122,6 +122,8 @@ class qemu:
             self.cmd.extend(["-drive", "file=" + self.config.qemu_image])
         if self.config.qemu_kernel:
             self.cmd.extend(["-kernel", self.config.qemu_kernel])
+            if self.config.qemu_append is None:
+                self.config.qemu_append = self.config.qemu_append_default
             if self.config.qemu_initrd:
                 self.cmd.extend(["-initrd", self.config.qemu_initrd])
         if self.config.qemu_bios:


### PR DESCRIPTION
This PR solves https://github.com/IntelLabs/kafl.fuzzer/issues/64 by only setting the `qemu_append` when `qemu_kernel` was already defined, based on a default setting.

