### PR TITLE
Fix wrong type for main_bitmap

### DIFF
--- a/kafl_fuzzer/manager/manager.py
+++ b/kafl_fuzzer/manager/manager.py
@@ -78,7 +78,7 @@ class ManagerTask:
         self.busy_events +=1
         if self.busy_events >= self.config.processes:
             self.busy_events = 0
-            main_bitmap = self.bitmap_storage.get_bitmap_for_node_type("regular").c_bitmap
+            main_bitmap = bytes(self.bitmap_storage.get_bitmap_for_node_type("regular").c_bitmap)
             if mmh3.hash(main_bitmap) == self.empty_hash:
                 logger.warn("Coverage bitmap is empty?! Check -ip0 or try better seeds.")
 


### PR DESCRIPTION
Fix https://github.com/IntelLabs/kAFL/issues/298
This appears to happen when the target is slow and the manager tries to check for initial coverage? It can also happen when using multiple instances. The commit fixes the incorrect required type for `mm3.hash`.