### PR TITLE
worker: fix mmh3.hash64 argument by converting to bytes

### DIFF
--- a/kafl_fuzzer/worker/execution_result.py
+++ b/kafl_fuzzer/worker/execution_result.py
@@ -63,7 +63,7 @@ class ExecutionResult:
             assert not pre_lut, "Request pre-LUT hash but LUT has been applied already."
         else:
             self.apply_lut()
-        return "%016x" % mmh3.hash64(self.cbuffer, seed=0xaaaaaaaa, x64arch=True, signed=False)[0]
+        return "%016x" % mmh3.hash64(bytes(self.cbuffer), seed=0xaaaaaaaa, x64arch=True, signed=False)[0]
 
     def apply_lut(self):
         if not self.lut_applied:


### PR DESCRIPTION
Another fix following https://github.com/IntelLabs/kAFL/issues/298 and #81 