### PR TITLE
fix wordlist_to_regex to handle byte strings

### DIFF
--- a/kafl_fuzzer/technique/grimoire_inference.py
+++ b/kafl_fuzzer/technique/grimoire_inference.py
@@ -26,8 +26,11 @@ class GrimoireInference:
 
     @staticmethod
     def wordlist_to_regex(words):
-        escaped = list(map(re.escape, words))
-        combined = '|'.join(sorted(escaped, key=len, reverse=True))
+        # escaped = list(map(re.escape, words))
+        # combined = '|'.join(sorted(escaped, key=len, reverse=True))
+        words_bytes = [w.encode() if isinstance(w, str) else w for w in words]                 
+        escaped = [re.escape(w) for w in words_bytes]
+        combined = b'|'.join(sorted(escaped, key=len, reverse=True))
         return re.compile(combined)
 
     def load_strings(self):
@@ -43,9 +46,10 @@ class GrimoireInference:
                     s = (l.split("=\"")[1].split("\"\n")[0])
                     if s == "":
                         continue
-                    self.tokens[tuple([c.encode() for c in s])] = 0
-                    strings.append(s)
-                except:
+                    s_bytes = s.encode() if isinstance(s, str) else bytes(s)
+                    self.tokens[tuple(bytes([c]) for c in s_bytes)] = 0
+                    strings.append(s_bytes)
+                except Exception:
                     pass
         self.strings = strings
         self.strings_regex = self.wordlist_to_regex(strings)

--- a/kafl_fuzzer/technique/grimoire_inference.py
+++ b/kafl_fuzzer/technique/grimoire_inference.py
@@ -28,7 +28,7 @@ class GrimoireInference:
     def wordlist_to_regex(words):
         # escaped = list(map(re.escape, words))
         # combined = '|'.join(sorted(escaped, key=len, reverse=True))
-        words_bytes = [w.encode() if isinstance(w, str) else w for w in words]                 
+        words_bytes = [w.encode() if isinstance(w, str) else w for w in words]
         escaped = [re.escape(w) for w in words_bytes]
         combined = b'|'.join(sorted(escaped, key=len, reverse=True))
         return re.compile(combined)
@@ -46,7 +46,7 @@ class GrimoireInference:
                     s = (l.split("=\"")[1].split("\"\n")[0])
                     if s == "":
                         continue
-                    s_bytes = s.encode() if isinstance(s, str) else bytes(s)
+                    s_bytes = s.encode()
                     self.tokens[tuple(bytes([c]) for c in s_bytes)] = 0
                     strings.append(s_bytes)
                 except Exception:


### PR DESCRIPTION
Fix exception when using girmoire switch e.g. 

```kafl fuzz --purge   --seed-dir seeds  --dict seeds/my.dict   --grimoire --radamsa   --kickstart 0   -p 8 -m 4096   -w /tmp/kafl  --redqueen --redqueen-hammer --redqueen-hashes --redqueen-simple --log --log-hprintf```

```
...<reacted>
Traceback (most recent call last):
  File "/usr/lib/python3.10/multiprocessing/process.py", line 314, in _bootstrap
    self.run()
  File "/usr/lib/python3.10/multiprocessing/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "/home/z/Documents/kAFL2/kafl/fuzzer/kafl_fuzzer/worker/worker.py", line 37, in worker_loader
    worker.start()
  File "/home/z/Documents/kAFL2/kafl/fuzzer/kafl_fuzzer/worker/worker.py", line 132, in start
    self.loop()
  File "/home/z/Documents/kAFL2/kafl/fuzzer/kafl_fuzzer/worker/worker.py", line 156, in loop
    self.handle_node(msg)
  File "/home/z/Documents/kAFL2/kafl/fuzzer/kafl_fuzzer/worker/worker.py", line 93, in handle_node
    results, new_payload = self.logic.process_node(payload, meta_data)
  File "/home/z/Documents/kAFL2/kafl/fuzzer/kafl_fuzzer/worker/state_logic.py", line 112, in process_node
    self.handle_havoc(payload, metadata)
  File "/home/z/Documents/kAFL2/kafl/fuzzer/kafl_fuzzer/worker/state_logic.py", line 284, in handle_havoc
    self.__perform_grimoire(payload, metadata)
  File "/home/z/Documents/kAFL2/kafl/fuzzer/kafl_fuzzer/worker/state_logic.py", line 253, in __perform_grimoire
    grimoire.havoc(tuple(grimoire_input), self.execute, self.grimoire, havoc_amount, generalized=True)
  File "/home/z/Documents/kAFL2/kafl/fuzzer/kafl_fuzzer/technique/grimoire_mutations.py", line 127, in havoc
    mutate_replace_strings(generalized_input, func, grimoire_inference, string_matches)
  File "/home/z/Documents/kAFL2/kafl/fuzzer/kafl_fuzzer/technique/grimoire_mutations.py", line 109, in mutate_replace_strings
    data = payload[0:match.start()] + rand_str + payload[match.end():]
TypeError: can't concat str to bytes```